### PR TITLE
feat: add pcov, apcu, and xdebug extensions

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+      - name: Prepare embedded lockfile
+        run: cp bundles.lock cmd/phpup/bundles.lock
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -40,10 +42,8 @@ jobs:
         run: go test -race -cover ./...
       - name: go build
         run: |
-          cp bundles.lock cmd/phpup/bundles.lock
           go build ./cmd/phpup
           go build ./cmd/planner
-          rm -f cmd/phpup/bundles.lock
 
   node-lint:
     name: Node.js Lint

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -33,7 +33,11 @@ jobs:
 
   build-ext:
     needs: [plan, build-php]
-    if: needs.plan.outputs.ext_matrix != '{"include":[]}'
+    if: |
+      always() &&
+      needs.plan.result == 'success' &&
+      needs.build-php.result != 'failure' &&
+      needs.plan.outputs.ext_matrix != '{"include":[]}'
     strategy:
       fail-fast: false
       max-parallel: 30

--- a/catalog/extensions/apcu.yaml
+++ b/catalog/extensions/apcu.yaml
@@ -1,0 +1,18 @@
+name: apcu
+kind: pecl
+source:
+  pecl_package: apcu
+versions:
+  - "5.1.28"
+abi_matrix:
+  php: ["8.4"]
+  os: ["linux"]
+  arch: ["x86_64"]
+  ts: ["nts"]
+runtime_deps:
+  linux: []
+ini:
+  - "extension=apcu"
+  - "apc.enable_cli=1"
+smoke:
+  - 'php -r "assert(extension_loaded(\"apcu\"));"'

--- a/catalog/extensions/pcov.yaml
+++ b/catalog/extensions/pcov.yaml
@@ -1,0 +1,17 @@
+name: pcov
+kind: pecl
+source:
+  pecl_package: pcov
+versions:
+  - "1.0.12"
+abi_matrix:
+  php: ["8.4"]
+  os: ["linux"]
+  arch: ["x86_64"]
+  ts: ["nts"]
+runtime_deps:
+  linux: []
+ini:
+  - "extension=pcov"
+smoke:
+  - 'php -r "assert(extension_loaded(\"pcov\"));"'

--- a/catalog/extensions/xdebug.yaml
+++ b/catalog/extensions/xdebug.yaml
@@ -1,0 +1,17 @@
+name: xdebug
+kind: pecl
+source:
+  pecl_package: xdebug
+versions:
+  - "3.5.1"
+abi_matrix:
+  php: ["8.4"]
+  os: ["linux"]
+  arch: ["x86_64"]
+  ts: ["nts"]
+runtime_deps:
+  linux: []
+ini:
+  - "zend_extension=xdebug"
+smoke:
+  - 'php -r "assert(extension_loaded(\"xdebug\"));"'


### PR DESCRIPTION
## Summary

Adds three commonly-requested PHP extensions to the catalog.

- **pcov** 1.0.12 — fast code coverage driver
- **apcu** 5.1.28 — user cache (with `apc.enable_cli=1` default for testing)
- **xdebug** 3.5.1 — debugger/profiler (loaded as `zend_extension`)

All three are PECL extensions with no exotic build dependencies.

## Test plan

- [ ] `ci-lint` green (no Go/Node changes)
- [ ] `on-push` builds the 3 new extension bundles and pushes signed artifacts to GHCR
- [ ] `integration-test` still 4/4 green (existing cells unaffected)
- [ ] After merge: `bundles.lock` auto-updated on `main` with 5 entries total