### PR TITLE
fix: drop component prefix from release-please tags

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "packages": {


### PR DESCRIPTION
## Summary

- release-please's first release (PR #1) produced the tag `setup-php-v1.0.0` because `include-component-in-tag` defaults to `true` when a package is named in manifest mode.
- That tag did not match `release-action.yml`'s trigger (`tags: ['v*']`) or `update-major-tag.yml`'s trigger (`tags: ['v*.*.*']`), so neither downstream workflow fired: no Go binaries were built, and no `v1` floating tag was created.
- `v1.0.0` and `v1` tags have already been manually created at commit `56baa25` to unblock action consumers; the orphan `setup-php-v1.0.0` tag/release will be cleaned up separately.

This change sets `include-component-in-tag: false` so future release-please runs produce plain `v<version>` tags matching the downstream pipeline patterns and the `uses: buildrush/setup-php@v1` convention.

## Test plan

- [x] Verified locally that JSON parses and schema is valid
- [ ] After merge, release-please runs on main and recognises `v1.0.0` as the previous release (no re-release of 1.0.0)
- [ ] Next `feat:`/`fix:` commit produces a Release PR proposing a `v<version>` tag (no `setup-php-` prefix)