### PR TITLE
fix: resolve release tag via GitHub API when downloading phpup

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -54,5 +54,6 @@ jobs:
         with:
           node-version: '24'
       - run: npm ci
-      - run: npx eslint src/
-      - run: npx prettier --check src/
+      - run: npx eslint src/ test/
+      - run: npx prettier --check src/ test/
+      - run: npm test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt fmt-check vet lint tidy tidy-check test build clean \
+.PHONY: check fmt fmt-check vet lint tidy tidy-check test test-node build clean \
         build-linux-amd64 build-linux-arm64 bundle-php bundle-ext
 
 # Ensure the embedded lockfile is available for go vet/test/build
@@ -6,18 +6,18 @@ cmd/phpup/bundles.lock: bundles.lock
 	@cp bundles.lock cmd/phpup/bundles.lock
 
 # Run all checks locally (mirrors CI exactly)
-check: fmt-check vet lint tidy-check test build
+check: fmt-check vet lint tidy-check test test-node build
 	@rm -f cmd/phpup/bundles.lock
 
 # Format all code
 fmt:
 	gofmt -s -w .
-	npx prettier --write src/
+	npx prettier --write src/ test/
 
 # Check formatting without modifying (CI mode)
 fmt-check:
 	@test -z "$$(gofmt -s -l .)" || (echo "Files need gofmt:"; gofmt -s -l .; exit 1)
-	npx prettier --check src/
+	npx prettier --check src/ test/
 
 # Go vet
 vet: cmd/phpup/bundles.lock
@@ -26,7 +26,7 @@ vet: cmd/phpup/bundles.lock
 # Lint (requires golangci-lint)
 lint:
 	golangci-lint run ./...
-	npx eslint src/
+	npx eslint src/ test/
 
 # Go mod tidy
 tidy:
@@ -43,6 +43,10 @@ tidy-check:
 # Test with race detector
 test: cmd/phpup/bundles.lock
 	go test -race -cover ./...
+
+# Node unit tests
+test-node:
+	npm test
 
 # Build all binaries (native platform)
 build: cmd/phpup/bundles.lock

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "private": true,
   "main": "src/index.js",
   "scripts": {
-    "lint": "eslint src/",
-    "format": "prettier --write src/",
-    "format:check": "prettier --check src/"
+    "lint": "eslint src/ test/",
+    "format": "prettier --write src/ test/",
+    "format:check": "prettier --check src/ test/",
+    "test": "node --test 'test/unit/*.test.js'"
   },
   "devDependencies": {
     "eslint": "^8.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,56 +1,164 @@
 'use strict';
 
 const { execFileSync } = require('child_process');
-const { existsSync, mkdirSync, chmodSync, createWriteStream } = require('fs');
+const { existsSync, mkdirSync, chmodSync, createWriteStream, unlinkSync } = require('fs');
 const { join } = require('path');
+const http = require('http');
 const https = require('https');
 
-const TOOL_CACHE = process.env.RUNNER_TOOL_CACHE || join(process.env.HOME, '.buildrush', 'cache');
-const OS = process.env.RUNNER_OS?.toLowerCase() || 'linux';
-const ARCH = process.env.RUNNER_ARCH === 'ARM64' ? 'arm64' : 'amd64';
+const USER_AGENT = 'buildrush/setup-php';
+const DEFAULT_API_BASE = 'https://api.github.com';
+const DEFAULT_REPO = 'buildrush/setup-php';
 
-async function downloadFile(url, dest) {
+function requestLib(url) {
+  return new URL(url).protocol === 'http:' ? http : https;
+}
+
+function httpGet(url, { headers = {}, maxRedirects = 5 } = {}) {
   return new Promise((resolve, reject) => {
-    const file = createWriteStream(dest);
-    https
-      .get(url, { headers: { 'User-Agent': 'buildrush/setup-php' } }, (res) => {
-        if (res.statusCode === 302 || res.statusCode === 301) {
-          https
-            .get(res.headers.location, (redirectRes) => {
-              redirectRes.pipe(file);
-              file.on('finish', () => {
-                file.close();
-                resolve();
-              });
-            })
-            .on('error', reject);
-          return;
-        }
-        res.pipe(file);
-        file.on('finish', () => {
-          file.close();
-          resolve();
-        });
-      })
-      .on('error', reject);
+    const follow = (current, redirects) => {
+      if (redirects > maxRedirects) {
+        reject(new Error(`Too many redirects fetching ${url}`));
+        return;
+      }
+      requestLib(current)
+        .get(current, { headers: { 'User-Agent': USER_AGENT, ...headers } }, (res) => {
+          const status = res.statusCode;
+          if (
+            (status === 301 || status === 302 || status === 307 || status === 308) &&
+            res.headers.location
+          ) {
+            res.resume();
+            const next = new URL(res.headers.location, current).toString();
+            follow(next, redirects + 1);
+            return;
+          }
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () =>
+            resolve({
+              statusCode: status,
+              headers: res.headers,
+              body: Buffer.concat(chunks),
+            }),
+          );
+          res.on('error', reject);
+        })
+        .on('error', reject);
+    };
+    follow(url, 0);
   });
 }
 
-async function main() {
-  // Determine binary name
-  const binaryName = OS === 'windows' ? 'phpup.exe' : 'phpup';
-  const platform = OS === 'macos' ? 'darwin' : OS;
-  const releaseBinary = `phpup-${platform}-${ARCH}`;
+async function githubJson(path, { token, apiBase = DEFAULT_API_BASE } = {}) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await httpGet(`${apiBase}${path}`, { headers });
+  if (res.statusCode < 200 || res.statusCode >= 300) {
+    const snippet = res.body.toString('utf8').slice(0, 200);
+    const err = new Error(`GitHub API ${path} returned HTTP ${res.statusCode}: ${snippet}`);
+    err.statusCode = res.statusCode;
+    throw err;
+  }
+  return JSON.parse(res.body.toString('utf8'));
+}
 
-  // Check tool cache for binary
-  const cacheDir = join(TOOL_CACHE, 'buildrush-bin');
+async function resolveReleaseTag(repo, ref, { token, apiBase } = {}) {
+  if (ref) {
+    try {
+      const release = await githubJson(`/repos/${repo}/releases/tags/${encodeURIComponent(ref)}`, {
+        token,
+        apiBase,
+      });
+      return release.tag_name;
+    } catch (err) {
+      if (err.statusCode !== 404) throw err;
+    }
+  }
+  const latest = await githubJson(`/repos/${repo}/releases/latest`, {
+    token,
+    apiBase,
+  });
+  const majorMatch = /^v(\d+)$/.exec(ref || '');
+  if (majorMatch) {
+    const latestMajor = /^v(\d+)/.exec(latest.tag_name);
+    if (!latestMajor || latestMajor[1] !== majorMatch[1]) {
+      throw new Error(`No release found for ${ref}; latest release is ${latest.tag_name}`);
+    }
+  }
+  return latest.tag_name;
+}
+
+async function downloadFile(url, dest, { maxRedirects = 5 } = {}) {
+  return new Promise((resolve, reject) => {
+    const follow = (current, redirects) => {
+      if (redirects > maxRedirects) {
+        reject(new Error(`Too many redirects fetching ${url}`));
+        return;
+      }
+      requestLib(current)
+        .get(current, { headers: { 'User-Agent': USER_AGENT } }, (res) => {
+          const status = res.statusCode;
+          if (
+            (status === 301 || status === 302 || status === 307 || status === 308) &&
+            res.headers.location
+          ) {
+            res.resume();
+            const next = new URL(res.headers.location, current).toString();
+            follow(next, redirects + 1);
+            return;
+          }
+          if (status < 200 || status >= 300) {
+            res.resume();
+            reject(new Error(`Download failed: ${current} returned HTTP ${status}`));
+            return;
+          }
+          const file = createWriteStream(dest);
+          let failed = false;
+          const fail = (err) => {
+            if (failed) return;
+            failed = true;
+            file.destroy();
+            try {
+              unlinkSync(dest);
+            } catch {
+              /* ignore */
+            }
+            reject(err);
+          };
+          res.on('error', fail);
+          file.on('error', fail);
+          res.pipe(file);
+          file.on('finish', () => file.close((err) => (err ? fail(err) : resolve())));
+        })
+        .on('error', reject);
+    };
+    follow(url, 0);
+  });
+}
+
+async function runMain({ env = process.env } = {}) {
+  const osName = (env.RUNNER_OS || 'linux').toLowerCase();
+  const arch = env.RUNNER_ARCH === 'ARM64' ? 'arm64' : 'amd64';
+  const toolCache = env.RUNNER_TOOL_CACHE || join(env.HOME || '/tmp', '.buildrush', 'cache');
+  const binaryName = osName === 'windows' ? 'phpup.exe' : 'phpup';
+  const platform = osName === 'macos' ? 'darwin' : osName;
+  const releaseBinary = `phpup-${platform}-${arch}`;
+
+  const cacheDir = join(toolCache, 'buildrush-bin');
   const cachedBinary = join(cacheDir, binaryName);
 
   if (!existsSync(cachedBinary)) {
-    // Download from this action's release
-    const actionRef = process.env.GITHUB_ACTION_REF || 'main';
-    const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || 'buildrush/setup-php';
-    const releaseUrl = `https://github.com/${actionRepo}/releases/download/${actionRef}/${releaseBinary}`;
+    const repo = env.GITHUB_ACTION_REPOSITORY || DEFAULT_REPO;
+    const ref = env.GITHUB_ACTION_REF || '';
+    const token = env.INPUT_GITHUB_TOKEN || env.GITHUB_TOKEN || '';
+
+    console.log(`Resolving release tag for ${repo}@${ref || '(unknown ref, will use latest)'}`);
+    const tag = await resolveReleaseTag(repo, ref, { token });
+    const releaseUrl = `https://github.com/${repo}/releases/download/${tag}/${releaseBinary}`;
 
     console.log(`Downloading phpup binary from ${releaseUrl}`);
     mkdirSync(cacheDir, { recursive: true });
@@ -58,18 +166,27 @@ async function main() {
     chmodSync(cachedBinary, 0o755);
   }
 
-  // Execute phpup with all inputs forwarded via env
   try {
     execFileSync(cachedBinary, [], {
       stdio: 'inherit',
-      env: process.env,
+      env,
     });
   } catch (err) {
     process.exitCode = err.status || 1;
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
-});
+module.exports = {
+  httpGet,
+  githubJson,
+  resolveReleaseTag,
+  downloadFile,
+  runMain,
+};
+
+if (require.main === module) {
+  runMain().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,0 +1,264 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { mkdtempSync, readFileSync, existsSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+
+const { httpGet, githubJson, resolveReleaseTag, downloadFile } = require('../../src/index.js');
+
+function startServer(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        server,
+        base: `http://127.0.0.1:${port}`,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+function makeTmpDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'setup-php-test-'));
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+test('httpGet returns status and body for 200', async () => {
+  const { base, close } = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('hello');
+  });
+  try {
+    const r = await httpGet(`${base}/x`);
+    assert.equal(r.statusCode, 200);
+    assert.equal(r.body.toString(), 'hello');
+  } finally {
+    await close();
+  }
+});
+
+test('httpGet follows 302 redirects', async () => {
+  const { base, close } = await startServer((req, res) => {
+    if (req.url === '/start') {
+      res.writeHead(302, { location: `${base}/dest` });
+      res.end();
+      return;
+    }
+    res.writeHead(200);
+    res.end('final');
+  });
+  try {
+    const r = await httpGet(`${base}/start`);
+    assert.equal(r.statusCode, 200);
+    assert.equal(r.body.toString(), 'final');
+  } finally {
+    await close();
+  }
+});
+
+test('httpGet rejects after too many redirects', async () => {
+  const { base, close } = await startServer((req, res) => {
+    res.writeHead(302, { location: `${base}/loop` });
+    res.end();
+  });
+  try {
+    await assert.rejects(() => httpGet(`${base}/loop`, { maxRedirects: 3 }), /Too many redirects/);
+  } finally {
+    await close();
+  }
+});
+
+test('githubJson parses 200 response', async () => {
+  const { base, close } = await startServer((req, res) => {
+    assert.equal(req.headers['user-agent'], 'buildrush/setup-php');
+    assert.equal(req.headers.accept, 'application/vnd.github+json');
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ tag_name: 'v1.2.3' }));
+  });
+  try {
+    const data = await githubJson('/repos/x/y/releases/latest', { apiBase: base });
+    assert.equal(data.tag_name, 'v1.2.3');
+  } finally {
+    await close();
+  }
+});
+
+test('githubJson sends bearer token when provided', async () => {
+  let seen;
+  const { base, close } = await startServer((req, res) => {
+    seen = req.headers.authorization;
+    res.writeHead(200);
+    res.end('{}');
+  });
+  try {
+    await githubJson('/anything', { apiBase: base, token: 'abc123' });
+    assert.equal(seen, 'Bearer abc123');
+  } finally {
+    await close();
+  }
+});
+
+test('githubJson throws with statusCode on 404', async () => {
+  const { base, close } = await startServer((req, res) => {
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+  try {
+    await assert.rejects(
+      () => githubJson('/missing', { apiBase: base }),
+      (err) => err.statusCode === 404 && /HTTP 404/.test(err.message),
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('resolveReleaseTag returns the ref when a release exists for it', async () => {
+  const { base, close } = await startServer((req, res) => {
+    if (req.url === '/repos/o/r/releases/tags/v1.2.3') {
+      res.writeHead(200);
+      res.end(JSON.stringify({ tag_name: 'v1.2.3' }));
+      return;
+    }
+    res.writeHead(500);
+    res.end('unexpected');
+  });
+  try {
+    const tag = await resolveReleaseTag('o/r', 'v1.2.3', { apiBase: base });
+    assert.equal(tag, 'v1.2.3');
+  } finally {
+    await close();
+  }
+});
+
+test('resolveReleaseTag falls back to latest for floating major tag', async () => {
+  const { base, close } = await startServer((req, res) => {
+    if (req.url === '/repos/o/r/releases/tags/v1') {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+    if (req.url === '/repos/o/r/releases/latest') {
+      res.writeHead(200);
+      res.end(JSON.stringify({ tag_name: 'v1.4.2' }));
+      return;
+    }
+    res.writeHead(500);
+    res.end();
+  });
+  try {
+    const tag = await resolveReleaseTag('o/r', 'v1', { apiBase: base });
+    assert.equal(tag, 'v1.4.2');
+  } finally {
+    await close();
+  }
+});
+
+test('resolveReleaseTag rejects when major mismatches latest', async () => {
+  const { base, close } = await startServer((req, res) => {
+    if (req.url === '/repos/o/r/releases/tags/v1') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    if (req.url === '/repos/o/r/releases/latest') {
+      res.writeHead(200);
+      res.end(JSON.stringify({ tag_name: 'v2.0.0' }));
+      return;
+    }
+    res.writeHead(500);
+    res.end();
+  });
+  try {
+    await assert.rejects(
+      () => resolveReleaseTag('o/r', 'v1', { apiBase: base }),
+      /No release found for v1/,
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('resolveReleaseTag falls back to latest for a non-semver ref (branch/SHA)', async () => {
+  const { base, close } = await startServer((req, res) => {
+    if (req.url === '/repos/o/r/releases/tags/main') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    if (req.url === '/repos/o/r/releases/latest') {
+      res.writeHead(200);
+      res.end(JSON.stringify({ tag_name: 'v1.4.2' }));
+      return;
+    }
+    res.writeHead(500);
+    res.end();
+  });
+  try {
+    const tag = await resolveReleaseTag('o/r', 'main', { apiBase: base });
+    assert.equal(tag, 'v1.4.2');
+  } finally {
+    await close();
+  }
+});
+
+test('downloadFile writes response body to disk on 200', async () => {
+  const { base, close } = await startServer((req, res) => {
+    res.writeHead(200);
+    res.end('binary-contents');
+  });
+  const { dir, cleanup } = makeTmpDir();
+  try {
+    const dest = join(dir, 'bin');
+    await downloadFile(`${base}/asset`, dest);
+    assert.equal(readFileSync(dest, 'utf8'), 'binary-contents');
+  } finally {
+    cleanup();
+    await close();
+  }
+});
+
+test('downloadFile rejects on 404 and does not leave a file behind', async () => {
+  const { base, close } = await startServer((req, res) => {
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+  const { dir, cleanup } = makeTmpDir();
+  try {
+    const dest = join(dir, 'bin');
+    await assert.rejects(() => downloadFile(`${base}/missing`, dest), /HTTP 404/);
+    assert.equal(existsSync(dest), false);
+  } finally {
+    cleanup();
+    await close();
+  }
+});
+
+test('downloadFile follows a redirect to the final asset URL', async () => {
+  const { base, close } = await startServer((req, res) => {
+    if (req.url === '/start') {
+      res.writeHead(302, { location: `${base}/asset` });
+      res.end();
+      return;
+    }
+    res.writeHead(200);
+    res.end('payload');
+  });
+  const { dir, cleanup } = makeTmpDir();
+  try {
+    const dest = join(dir, 'bin');
+    await downloadFile(`${base}/start`, dest);
+    assert.equal(readFileSync(dest, 'utf8'), 'payload');
+  } finally {
+    cleanup();
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary

- Using `buildrush/setup-php@v1` failed with `Syntax error: newline unexpected` because the action downloaded from `releases/download/v1/phpup-linux-amd64`, but only `v1.0.0` has published assets — `v1` is a floating git tag with no release attached. The 404 body was piped to disk and executed.
- The Node bootstrap now resolves `GITHUB_ACTION_REF` through the GitHub API (`/releases/tags/{ref}` with fallback to `/releases/latest`, plus a major-version guard for `vN` refs), so `@v1`, `@main`, and SHA pins all work.
- `downloadFile` now rejects on non-2xx, unlinks partial files, and follows redirects across hosts. Pure functions are exported so they can be unit-tested.
- Adds `test/unit/index.test.js` with 13 tests using `node --test` and a local HTTP server; wires `npm test` into `ci-lint` and `make check`.

## Test plan
- [x] `npm test` — 13/13 pass locally
- [x] `make check` — green
- [ ] CI `ci-lint` passes on this PR
- [ ] After merge + release, retry the failing job from the upstream consumer repo and confirm the `Install PHP` step succeeds

## Release note

Consumers pinned to `@v1` stay broken until a new release is cut and `update-major-tag.yml` moves the `v1` tag forward onto this fix. Release-please should produce `v1.0.1` on merge.