### PR TITLE
chore: add dependabot config for go, npm, and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-deps:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` enabling weekly dependency updates for Go modules, npm, and GitHub Actions
- Groups updates per ecosystem to reduce PR noise
- Uses `chore` conventional-commit prefix per repo convention

## Test plan
- [ ] Verify Dependabot activates on the `.github/dependabot.yml` file after merge
- [ ] Confirm first scheduled run opens grouped PRs (not one-per-dep)