### PR TITLE
ci: add aggregator gate jobs for stable branch protection

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -57,3 +57,13 @@ jobs:
       - run: npx eslint src/ test/
       - run: npx prettier --check src/ test/
       - run: npm test
+
+  ci-lint-gate:
+    name: ci-lint gate
+    if: always()
+    needs: [go-lint, node-lint]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -100,3 +100,13 @@ jobs:
           echo "Resolved version: $PHP_VERSION"
           test -n "$PHP_VERSION"
           [[ "$PHP_VERSION" == 8.4* ]]
+
+  integration-gate:
+    name: integration-test gate
+    if: always()
+    needs: [build, test]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- Adds a single "gate" aggregator job to `ci-lint.yml` (`ci-lint gate`) and `integration-test.yml` (`integration-test gate`) using `re-actors/alls-green@release/v1`
- Branch protection can then require just these 2 stable check names — adding new jobs to a workflow only requires appending them to the gate's `needs:` list, not touching the ruleset
- `alls-green` correctly handles `skipped`/`cancelled` job outcomes (a naive `if: success()` gate silently passes when a needed job is skipped)

## Follow-up
After this merges, update ruleset `15196560` on `main` to add `required_status_checks` with the two contexts:
- `ci-lint gate`
- `integration-test gate`

## Test plan
- [ ] Both gate jobs appear green on this PR alongside the existing checks
- [ ] Confirm `needs: [build, test]` correctly awaits all 4 matrix entries of `test`