### PR TITLE
fix: move floating major tag from release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,28 @@ jobs:
   release-please:
     runs-on: ubuntu-24.04
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      - uses: actions/checkout@v6
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          fetch-depth: 0
+
+      - name: Move floating major tag
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            v*.*.*-*) echo "Skipping prerelease $TAG"; exit 0 ;;
+          esac
+          MAJOR="${TAG%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f "$MAJOR" "$TAG"
+          git push origin "$MAJOR" --force


### PR DESCRIPTION
## Summary
- The standalone `update-major-tag` workflow never fires for release-please releases, because tag pushes made with `GITHUB_TOKEN` do not trigger downstream workflows. Result: `v1` was stuck on `v1.0.0` after `v1.0.1` shipped, breaking `uses: buildrush/setup-php@v1` consumers (the old `src/index.js` lacked the API-based tag resolution and 404'd on `releases/download/v1/...`).
- Move the major-tag logic into `release-please.yml` itself so it runs in the same workflow that created the release, sidestepping the trigger restriction.
- The `v1` floating tag was force-moved to `v1.0.1` out of band to unblock consumers immediately.

## Test plan
- [ ] Next release-please release moves the corresponding `vN` tag automatically.
- [ ] `update-major-tag.yml` can be removed in a follow-up once verified.