### PR TITLE
feat: install coverage driver when coverage input is set

### DIFF
--- a/cmd/phpup/main.go
+++ b/cmd/phpup/main.go
@@ -45,10 +45,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("parse inputs: %v", err)
 	}
+	p.ApplyCoverage()
 
 	if p.Verbose {
-		log.Printf("Plan: PHP %s, extensions=%v, os=%s, arch=%s, ts=%s",
-			p.PHPVersion, p.Extensions, p.OS, p.Arch, p.ThreadSafety)
+		log.Printf("Plan: PHP %s, extensions=%v, os=%s, arch=%s, ts=%s, coverage=%s",
+			p.PHPVersion, p.Extensions, p.OS, p.Arch, p.ThreadSafety, p.Coverage)
 	}
 
 	// 2. Load embedded lockfile
@@ -61,7 +62,9 @@ func main() {
 	cat := &catalog.Catalog{
 		PHP: &catalog.PHPSpec{BundledExtensions: bundledExtensions},
 		Extensions: map[string]*catalog.ExtensionSpec{
-			"redis": {Name: "redis", Kind: catalog.ExtensionKindPECL, Versions: []string{"6.2.0"}},
+			"redis":  {Name: "redis", Kind: catalog.ExtensionKindPECL, Versions: []string{"6.2.0"}},
+			"xdebug": {Name: "xdebug", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.5.1"}, Ini: []string{"zend_extension=xdebug", "xdebug.mode=coverage"}},
+			"pcov":   {Name: "pcov", Kind: catalog.ExtensionKindPECL, Versions: []string{"1.0.12"}, Ini: []string{"extension=pcov", "pcov.enabled=1"}},
 		},
 	}
 

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -116,6 +117,26 @@ func ParsePHPVersionFile(path string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(data)), nil
+}
+
+// ApplyCoverage adds the requested coverage driver (xdebug or pcov) to the
+// extensions list so it is resolved, fetched, and composed like any other
+// extension. "none" is a no-op.
+func (p *Plan) ApplyCoverage() {
+	var driver string
+	switch p.Coverage {
+	case CoverageXdebug:
+		driver = "xdebug"
+	case CoveragePCOV:
+		driver = "pcov"
+	default:
+		return
+	}
+	if slices.Contains(p.Extensions, driver) {
+		return
+	}
+	p.Extensions = append(p.Extensions, driver)
+	sort.Strings(p.Extensions)
 }
 
 func (p *Plan) Hash() string {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -110,6 +110,38 @@ func TestParsePHPVersionFile(t *testing.T) {
 	}
 }
 
+func TestApplyCoverage(t *testing.T) {
+	tests := []struct {
+		name     string
+		coverage CoverageDriver
+		initial  []string
+		want     []string
+	}{
+		{"none is no-op", CoverageNone, []string{"intl"}, []string{"intl"}},
+		{"empty is no-op", CoverageDriver(""), []string{"intl"}, []string{"intl"}},
+		{"xdebug adds driver", CoverageXdebug, []string{"intl"}, []string{"intl", "xdebug"}},
+		{"pcov adds driver", CoveragePCOV, []string{"intl"}, []string{"intl", "pcov"}},
+		{"xdebug keeps sort order", CoverageXdebug, []string{"redis"}, []string{"redis", "xdebug"}},
+		{"pcov sorted before redis", CoveragePCOV, []string{"redis"}, []string{"pcov", "redis"}},
+		{"already present: no duplicate", CoverageXdebug, []string{"xdebug"}, []string{"xdebug"}},
+		{"empty extensions + xdebug", CoverageXdebug, nil, []string{"xdebug"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plan{Coverage: tt.coverage, Extensions: append([]string(nil), tt.initial...)}
+			p.ApplyCoverage()
+			if len(p.Extensions) != len(tt.want) {
+				t.Fatalf("Extensions = %v, want %v", p.Extensions, tt.want)
+			}
+			for i := range p.Extensions {
+				if p.Extensions[i] != tt.want[i] {
+					t.Errorf("Extensions[%d] = %q, want %q", i, p.Extensions[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestHashDeterminism(t *testing.T) {
 	p := &Plan{
 		PHPVersion:   "8.4",


### PR DESCRIPTION
## Summary

- The `coverage` input was parsed but never applied. PHPUnit runs with `--coverage-*` aborted with `No code coverage driver available` / `No tests executed!` unless the runner's system PHP happened to ship a driver.
- `Plan.ApplyCoverage` now adds the requested driver to the effective extensions list so the existing resolve/fetch/compose pipeline installs and configures it from the catalog.
- `coverage: xdebug` → `xdebug.mode=coverage`; `coverage: pcov` → `pcov.enabled=1`; `coverage: none` (default) unchanged.

## Test plan

- [x] `make check` (gofmt, vet, golangci-lint, go test -race -cover, eslint, build)
- [x] New table test `TestApplyCoverage` covers: none, empty, xdebug, pcov, already-present, empty extensions
- [ ] End-to-end: add `coverage: pcov` to a workflow consuming `buildrush/setup-php@v1` and confirm `--coverage-cobertura` runs