### PR TITLE
fix: stop treating the floating major tag as a GitHub release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,3 +65,22 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -f "$MAJOR" "$TAG"
           git push origin "$MAJOR" --force
+
+      # The floating major tag must be a git-ref only -- never a GitHub Release.
+      # A standalone vN release would hijack src/index.js:resolveReleaseTag and
+      # pin consumers to stale assets. Delete one if it somehow exists.
+      - name: Ensure no standalone major-tag release exists
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            v*.*.*-*) exit 0 ;;
+          esac
+          MAJOR="${TAG%%.*}"
+          if gh release view "$MAJOR" --json tagName >/dev/null 2>&1; then
+            echo "::warning::Standalone $MAJOR release found; deleting (violates release-artifact contract)"
+            gh release delete "$MAJOR" --yes --cleanup-tag=false
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,9 @@ All code changes MUST pass `make check` before committing. This runs:
 - Smoke tests: `test/smoke/run.sh` for bundle verification.
 - Integration tests: `.github/workflows/integration-test.yml` (CI only).
 - Local bundle builds: `make bundle-php` and `make bundle-ext` (requires Docker).
+
+## Release Engineering
+
+- Only specific-version tags (`vX.Y.Z`) get GitHub Releases with built assets. The floating major-tag (`vN`) is a git-ref convenience for `uses: buildrush/setup-php@v1` only and MUST NOT have a corresponding GitHub Release.
+- Release assets are built and uploaded inside `release-please.yml`, in the same job that creates the release. Never add a separate `push: tags:` workflow for release artifacts — `GITHUB_TOKEN`-originated tag pushes don't trigger downstream workflows, so such a workflow would silently skip release-please-created tags.
+- `src/index.js:resolveReleaseTag` enforces the major-tag convention: floating-major refs (matching `/^v\d+$/`) bypass `/releases/tags/<ref>` and resolve through `/releases/latest` + major-match. Specific-version refs (matching `/^v\d+\.\d+\.\d+/`) that 404 on lookup throw instead of silently substituting `latest`, to honor pin reproducibility.

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,13 @@ async function githubJson(path, { token, apiBase = DEFAULT_API_BASE } = {}) {
 }
 
 async function resolveReleaseTag(repo, ref, { token, apiBase } = {}) {
-  if (ref) {
+  const isFloatingMajor = /^v\d+$/.test(ref || '');
+  const isSpecificVersion = /^v\d+\.\d+\.\d+/.test(ref || '');
+
+  // Floating major tags (v1, v2) are a git-ref convenience for `uses:` syntax only.
+  // They must never have a corresponding GitHub Release; resolve via latest + major-match
+  // so a stray major-tag release can't hijack resolution.
+  if (ref && !isFloatingMajor) {
     try {
       const release = await githubJson(`/repos/${repo}/releases/tags/${encodeURIComponent(ref)}`, {
         token,
@@ -76,14 +82,19 @@ async function resolveReleaseTag(repo, ref, { token, apiBase } = {}) {
       return release.tag_name;
     } catch (err) {
       if (err.statusCode !== 404) throw err;
+      if (isSpecificVersion) {
+        throw new Error(`No release found for pinned version ${ref}`);
+      }
+      // Branch/SHA ref: fall through to latest (development use case).
     }
   }
+
   const latest = await githubJson(`/repos/${repo}/releases/latest`, {
     token,
     apiBase,
   });
-  const majorMatch = /^v(\d+)$/.exec(ref || '');
-  if (majorMatch) {
+  if (isFloatingMajor) {
+    const majorMatch = /^v(\d+)$/.exec(ref);
     const latestMajor = /^v(\d+)/.exec(latest.tag_name);
     if (!latestMajor || latestMajor[1] !== majorMatch[1]) {
       throw new Error(`No release found for ${ref}; latest release is ${latest.tag_name}`);

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -139,11 +139,37 @@ test('resolveReleaseTag returns the ref when a release exists for it', async () 
   }
 });
 
-test('resolveReleaseTag falls back to latest for floating major tag', async () => {
+test('resolveReleaseTag resolves a floating major tag via /releases/latest without hitting /releases/tags', async () => {
+  const tagsCalls = [];
+  const { base, close } = await startServer((req, res) => {
+    if (req.url.startsWith('/repos/o/r/releases/tags/')) {
+      tagsCalls.push(req.url);
+      res.writeHead(500);
+      res.end('should not be called for floating major tag');
+      return;
+    }
+    if (req.url === '/repos/o/r/releases/latest') {
+      res.writeHead(200);
+      res.end(JSON.stringify({ tag_name: 'v1.4.2' }));
+      return;
+    }
+    res.writeHead(500);
+    res.end();
+  });
+  try {
+    const tag = await resolveReleaseTag('o/r', 'v1', { apiBase: base });
+    assert.equal(tag, 'v1.4.2');
+    assert.deepEqual(tagsCalls, []);
+  } finally {
+    await close();
+  }
+});
+
+test('resolveReleaseTag ignores a standalone floating-major release and uses latest', async () => {
   const { base, close } = await startServer((req, res) => {
     if (req.url === '/repos/o/r/releases/tags/v1') {
-      res.writeHead(404);
-      res.end('Not Found');
+      res.writeHead(200);
+      res.end(JSON.stringify({ tag_name: 'v1' }));
       return;
     }
     if (req.url === '/repos/o/r/releases/latest') {
@@ -164,11 +190,6 @@ test('resolveReleaseTag falls back to latest for floating major tag', async () =
 
 test('resolveReleaseTag rejects when major mismatches latest', async () => {
   const { base, close } = await startServer((req, res) => {
-    if (req.url === '/repos/o/r/releases/tags/v1') {
-      res.writeHead(404);
-      res.end();
-      return;
-    }
     if (req.url === '/repos/o/r/releases/latest') {
       res.writeHead(200);
       res.end(JSON.stringify({ tag_name: 'v2.0.0' }));
@@ -181,6 +202,31 @@ test('resolveReleaseTag rejects when major mismatches latest', async () => {
     await assert.rejects(
       () => resolveReleaseTag('o/r', 'v1', { apiBase: base }),
       /No release found for v1/,
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('resolveReleaseTag rejects when a specific-version release is missing', async () => {
+  const { base, close } = await startServer((req, res) => {
+    if (req.url === '/repos/o/r/releases/tags/v1.0.1') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    if (req.url === '/repos/o/r/releases/latest') {
+      res.writeHead(200);
+      res.end(JSON.stringify({ tag_name: 'v1.1.0' }));
+      return;
+    }
+    res.writeHead(500);
+    res.end();
+  });
+  try {
+    await assert.rejects(
+      () => resolveReleaseTag('o/r', 'v1.0.1', { apiBase: base }),
+      /No release found for pinned version v1\.0\.1/,
     );
   } finally {
     await close();


### PR DESCRIPTION
## Summary
After PR #15 + v1.1.1, `@v1` consumers were still hitting the stale binary. Root cause: a **standalone `v1` GitHub Release** (uploaded when PR #10 out-of-band force-pushed the v1 git tag and triggered the old `release-action.yml`) hijacks `resolveReleaseTag` — it finds `/releases/tags/v1` → 200 → returns `v1` → downloads the v1.0.1-era binary without PR #14's coverage-driver install. PHPUnit then reports *"No code coverage driver available / No tests executed"*.

The intent of the existing resolver is already that `@v1` resolves via `/releases/latest` + major-match (see `resolveReleaseTag falls back to latest for floating major tag` test). The bug is that nothing enforced it. This PR encodes the contract in code, workflow, and docs.

## Architectural contract (now codified)
> The `v<MAJOR>` git tag is a **git-ref convenience** for `uses: owner/repo@v1` checkout only. It MUST NOT have a corresponding GitHub Release. Only specific-version tags (`vX.Y.Z`) get releases with assets.

## Changes
- **`src/index.js:resolveReleaseTag`**: floating-major refs (`/^v\d+$/`) skip `/releases/tags/<ref>` entirely and resolve via `/releases/latest` + major-match. Specific-version refs (`/^v\d+\.\d+\.\d+/`) that 404 on lookup now **throw** instead of silently substituting `latest` (pre-existing bug: violated pin reproducibility).
- **`.github/workflows/release-please.yml`**: new *Ensure no standalone major-tag release exists* step after the major-tag move — belt-and-braces cleanup if a `v1` release ever appears (shouldn't post-PR #15, but cheap insurance).
- **`test/unit/index.test.js`**: 1 existing test strengthened (proves resolver doesn't call `/releases/tags/` for floating major), 2 new tests — *ignores a standalone floating-major release* (direct regression test for today's incident) and *rejects when a specific-version release is missing*.
- **`CLAUDE.md`**: new *Release Engineering* section documenting the contract.

## Post-merge cleanup (out of band, with your OK)
```
gh release delete v1      --yes --cleanup-tag=false
gh release delete v1.0.1  --yes --cleanup-tag=false
gh release delete v1.1.0  --yes --cleanup-tag=false
```
Git tags preserved in all three cases. `@v1` then resolves via latest-major-match to `v1.1.1`.

## Test plan
- [x] `npm test` — 15/15 pass
- [x] `make check` — green
- [x] `actionlint` — clean
- [ ] After merge: delete `v1`, `v1.0.1`, `v1.1.0` GitHub releases
- [ ] After cleanup: re-run failing consumer workflow → green