### PR TITLE
feat: phase 2 compat-first slice (v0.2.0-alpha.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bcmath, calendar, ctype, curl, dom, exif, filter, ftp, gd, hash, iconv, intl, js
 
 Every input declared by v2 is declared here: `php-version`, `php-version-file`, `extensions`, `ini-file`, `ini-values`, `coverage`, `tools`, plus the env-var-driven `phpts`, `update`, `fail-fast`. Inputs we cannot implement given our prebuilt-bundle architecture (e.g. `update`) are accepted for parse compatibility and emit a `::warning::` line when set to a non-default value, so your workflow keeps running.
 
-Defaults match v2 where they are observable: `date.timezone=UTC` and `memory_limit=-1` are applied unless you override them in `ini-values`. The per-PHP-version compiled-in extension set is tracked against the `ondrej/php` PPA baseline v2 relies on.
+Defaults match v2 where they are observable: `date.timezone=UTC` and `memory_limit=-1` are applied unless you override them in `ini-values`. The per-PHP-version compiled-in extension baseline is audited against the `ondrej/php` PPA that v2 relies on; see [docs/compat-matrix.md](docs/compat-matrix.md) for the current delta.
 
 Extension list syntax works the same way:
 

--- a/README.md
+++ b/README.md
@@ -22,26 +22,30 @@ This means setup typically completes in single-digit seconds, and every run gets
 
 ## Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `php-version` | PHP version to install | `8.4` |
-| `extensions` | Comma-separated extensions | — |
-| `ini-values` | Comma-separated ini settings | — |
-| `coverage` | Coverage driver (xdebug, pcov, none) | `none` |
-| `tools` | Comma-separated tools | — |
-| `php-version-file` | File containing PHP version | — |
+| Input              | Description                                                                                                    | Default      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------- | ------------ |
+| `php-version`      | PHP version to install                                                                                         | `8.4`        |
+| `phpts`            | Thread safety (`nts` or `zts`). Only `nts` bundles are published today; see compat section below.              | `nts`        |
+| `extensions`       | Comma-separated extensions (supports `:ext` to exclude and `none` to reset).                                   | —            |
+| `ini-values`       | Comma-separated ini settings (`key=value`).                                                                    | —            |
+| `ini-file`         | Base ini template (`production` or `development`). Only `production` is currently applied; see compat section. | `production` |
+| `coverage`         | Coverage driver (`xdebug`, `pcov`, `none`).                                                                    | `none`       |
+| `tools`            | Comma-separated tools to install.                                                                              | —            |
+| `update`           | Accepted for v2 parse compatibility; no-op under prebuilt bundles. See compat section.                         | `false`      |
+| `fail-fast`        | Promote soft fallbacks (e.g. ZTS not available) to hard errors.                                                | `false`      |
+| `php-version-file` | File containing PHP version.                                                                                   | —            |
 
 ## Outputs
 
-| Output | Description |
-|--------|-------------|
+| Output        | Description                          |
+| ------------- | ------------------------------------ |
 | `php-version` | Resolved PHP version (e.g., `8.4.6`) |
 
 ## Supported Matrix
 
-| OS | Arch | PHP | Thread Safety |
-|----|------|-----|---------------|
-| Linux (Ubuntu 24.04) | x86_64 | 8.4 | NTS |
+| OS                   | Arch   | PHP | Thread Safety |
+| -------------------- | ------ | --- | ------------- |
+| Linux (Ubuntu 24.04) | x86_64 | 8.4 | NTS           |
 
 ### Bundled Extensions
 
@@ -52,8 +56,25 @@ bcmath, calendar, ctype, curl, dom, exif, filter, ftp, gd, hash, iconv, intl, js
 ### Separately Installable Extensions
 
 | Extension | Version |
-|-----------|---------|
-| redis | 6.2.0 |
+| --------- | ------- |
+| redis     | 6.2.0   |
+
+## Compatibility with `shivammathur/setup-php@v2`
+
+`buildrush/setup-php` is designed as a drop-in replacement for `shivammathur/setup-php@v2`. Existing workflows can migrate by changing only the `uses:` line.
+
+Every input declared by v2 is declared here: `php-version`, `php-version-file`, `extensions`, `ini-file`, `ini-values`, `coverage`, `tools`, plus the env-var-driven `phpts`, `update`, `fail-fast`. Inputs we cannot implement given our prebuilt-bundle architecture (e.g. `update`) are accepted for parse compatibility and emit a `::warning::` line when set to a non-default value, so your workflow keeps running.
+
+Defaults match v2 where they are observable: `date.timezone=UTC` and `memory_limit=-1` are applied unless you override them in `ini-values`. The per-PHP-version compiled-in extension set is tracked against the `ondrej/php` PPA baseline v2 relies on.
+
+Extension list syntax works the same way:
+
+```yaml
+extensions: redis, :opcache        # include redis, exclude opcache
+extensions: none, redis, curl      # reset, then only redis + curl
+```
+
+Details, deliberate deviations, and deferred behavioral quirks are catalogued in [docs/compat-matrix.md](docs/compat-matrix.md).
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: '8.4'
   phpts:
-    description: 'Thread safety (nts or zts). Only nts is currently built; zts falls back to nts with a warning.'
+    description: "Thread safety ('nts' or 'zts'). Only nts bundles are currently published; zts falls back to nts with a warning (or errors under fail-fast: true)."
     required: false
     default: 'nts'
   extensions:
@@ -20,7 +20,7 @@ inputs:
     description: 'Comma-separated list of php.ini values (key=value)'
     required: false
   ini-file:
-    description: "Base ini template ('production' or 'development'). Currently only 'production' is honored; other values emit a warning."
+    description: "Base ini template ('production' or 'development'). Only 'production' is currently supported; other values emit a warning and are ignored."
     required: false
     default: 'production'
   coverage:
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: 'false'
   fail-fast:
-    description: 'Promote soft fallbacks (e.g. ZTS not available, unknown extension, unsupported tools) to hard errors.'
+    description: 'Promote soft fallbacks (e.g. ZTS not available, unsupported tools input) to hard errors.'
     required: false
     default: 'false'
   php-version-file:

--- a/action.yml
+++ b/action.yml
@@ -9,12 +9,20 @@ inputs:
     description: 'PHP version to set up'
     required: false
     default: '8.4'
+  phpts:
+    description: 'Thread safety (nts or zts). Only nts is currently built; zts falls back to nts with a warning.'
+    required: false
+    default: 'nts'
   extensions:
     description: 'Comma-separated list of PHP extensions to install'
     required: false
   ini-values:
     description: 'Comma-separated list of php.ini values (key=value)'
     required: false
+  ini-file:
+    description: "Base ini template ('production' or 'development'). Currently only 'production' is honored; other values emit a warning."
+    required: false
+    default: 'production'
   coverage:
     description: 'Coverage driver to set up (xdebug, pcov, none)'
     required: false
@@ -22,6 +30,14 @@ inputs:
   tools:
     description: 'Comma-separated list of tools to install'
     required: false
+  update:
+    description: 'Update pre-installed PHP. No-op under prebuilt bundles; accepted for compatibility with shivammathur/setup-php@v2.'
+    required: false
+    default: 'false'
+  fail-fast:
+    description: 'Promote soft fallbacks (e.g. ZTS not available, unknown extension, unsupported tools) to hard errors.'
+    required: false
+    default: 'false'
   php-version-file:
     description: 'File containing PHP version'
     required: false

--- a/builders/linux/build-php.sh
+++ b/builders/linux/build-php.sh
@@ -33,7 +33,8 @@ $SUDO apt-get install -y -qq \
   libicu-dev libcurl4-openssl-dev libzip-dev libsqlite3-dev \
   libpq-dev libonig-dev libreadline-dev libsodium-dev \
   libfreetype6-dev libjpeg-dev libwebp-dev libxml2-dev \
-  zlib1g-dev libssl-dev gnupg2 xz-utils curl
+  zlib1g-dev libssl-dev gnupg2 xz-utils curl \
+  libffi-dev gettext
 echo "::endgroup::"
 
 # Download PHP source
@@ -73,6 +74,14 @@ cd /tmp/php-src
   --with-webp \
   --with-pdo-pgsql \
   --with-pgsql \
+  --with-ffi \
+  --with-gettext \
+  --enable-pcntl \
+  --enable-posix \
+  --enable-shmop \
+  --enable-sysvmsg \
+  --enable-sysvsem \
+  --enable-sysvshm \
   --disable-cgi \
   --enable-opcache
 echo "::endgroup::"

--- a/catalog/php.yaml
+++ b/catalog/php.yaml
@@ -185,6 +185,14 @@ versions:
         --with-freetype
         --with-jpeg
         --with-webp
+        --with-ffi
+        --with-gettext
+        --enable-pcntl
+        --enable-posix
+        --enable-shmop
+        --enable-sysvmsg
+        --enable-sysvsem
+        --enable-sysvshm
       linux: >-
         --with-pdo-pgsql
         --with-pgsql

--- a/catalog/php.yaml
+++ b/catalog/php.yaml
@@ -1,75 +1,232 @@
 name: php
-# Phase 1: single version, expanded as more versions are added
+# Per-version compat data. Only versions with `sources:` are built by the
+# pipeline; the rest encode `bundled_extensions` for future builds and for
+# cross-validation against internal/compat.BundledExtensions (guarded by
+# internal/catalog/catalog_compat_test.go).
+#
+# bundled_extensions are the *normalized lowercase identifiers* as returned
+# by internal/compat.BundledExtensions, matching what `extensions:` input
+# accepts at runtime.
 versions:
-  - "8.4"
-source:
-  url: "https://www.php.net/distributions/php-{version}.tar.xz"
-  sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
-abi_matrix:
-  os: ["linux"]
-  arch: ["x86_64"]
-  ts: ["nts"]
-configure_flags:
-  common: >-
-    --enable-mbstring
-    --with-curl
-    --with-zlib
-    --with-openssl
-    --enable-bcmath
-    --enable-calendar
-    --enable-exif
-    --enable-ftp
-    --enable-intl
-    --with-zip
-    --enable-soap
-    --enable-sockets
-    --with-pdo-mysql
-    --with-pdo-sqlite
-    --with-sqlite3
-    --with-readline
-    --with-sodium
-    --enable-gd
-    --with-freetype
-    --with-jpeg
-    --with-webp
-  linux: >-
-    --with-pdo-pgsql
-    --with-pgsql
-bundled_extensions:
-  - mbstring
-  - curl
-  - intl
-  - zip
-  - json
-  - pdo
-  - pdo_mysql
-  - pdo_sqlite
-  - sqlite3
-  - tokenizer
-  - xml
-  - dom
-  - simplexml
-  - xmlreader
-  - xmlwriter
-  - ctype
-  - filter
-  - hash
-  - iconv
-  - session
-  - bcmath
-  - calendar
-  - exif
-  - ftp
-  - soap
-  - sockets
-  - sodium
-  - gd
-  - readline
-  - openssl
-  - zlib
-  - opcache
-  - pgsql
-  - pdo_pgsql
+  "8.1":
+    bundled_extensions:
+      - calendar
+      - core
+      - ctype
+      - date
+      - exif
+      - ffi
+      - fileinfo
+      - filter
+      - ftp
+      - gettext
+      - hash
+      - iconv
+      - json
+      - libxml
+      - openssl
+      - pcntl
+      - pcre
+      - pdo
+      - phar
+      - posix
+      - readline
+      - reflection
+      - session
+      - shmop
+      - sockets
+      - sodium
+      - spl
+      - standard
+      - sysvmsg
+      - sysvsem
+      - sysvshm
+      - tokenizer
+      - opcache
+      - zlib
+  "8.2":
+    bundled_extensions:
+      - calendar
+      - core
+      - ctype
+      - date
+      - exif
+      - ffi
+      - fileinfo
+      - filter
+      - ftp
+      - gettext
+      - hash
+      - iconv
+      - json
+      - libxml
+      - openssl
+      - pcntl
+      - pcre
+      - pdo
+      - phar
+      - posix
+      - random
+      - readline
+      - reflection
+      - session
+      - shmop
+      - sockets
+      - sodium
+      - spl
+      - standard
+      - sysvmsg
+      - sysvsem
+      - sysvshm
+      - tokenizer
+      - opcache
+      - zlib
+  "8.3":
+    bundled_extensions:
+      - calendar
+      - core
+      - ctype
+      - date
+      - exif
+      - ffi
+      - fileinfo
+      - filter
+      - ftp
+      - gettext
+      - hash
+      - iconv
+      - json
+      - libxml
+      - openssl
+      - pcntl
+      - pcre
+      - pdo
+      - phar
+      - posix
+      - random
+      - readline
+      - reflection
+      - session
+      - shmop
+      - sockets
+      - sodium
+      - spl
+      - standard
+      - sysvmsg
+      - sysvsem
+      - sysvshm
+      - tokenizer
+      - opcache
+      - zlib
+  "8.4":
+    bundled_extensions:
+      - calendar
+      - core
+      - ctype
+      - date
+      - exif
+      - ffi
+      - fileinfo
+      - filter
+      - ftp
+      - gettext
+      - hash
+      - iconv
+      - json
+      - libxml
+      - openssl
+      - pcntl
+      - pcre
+      - pdo
+      - phar
+      - posix
+      - random
+      - readline
+      - reflection
+      - session
+      - shmop
+      - sockets
+      - sodium
+      - spl
+      - standard
+      - sysvmsg
+      - sysvsem
+      - sysvshm
+      - tokenizer
+      - opcache
+      - zlib
+    sources:
+      url: "https://www.php.net/distributions/php-{version}.tar.xz"
+      sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
+    abi_matrix:
+      os: ["linux"]
+      arch: ["x86_64"]
+      ts: ["nts"]
+    configure_flags:
+      common: >-
+        --enable-mbstring
+        --with-curl
+        --with-zlib
+        --with-openssl
+        --enable-bcmath
+        --enable-calendar
+        --enable-exif
+        --enable-ftp
+        --enable-intl
+        --with-zip
+        --enable-soap
+        --enable-sockets
+        --with-pdo-mysql
+        --with-pdo-sqlite
+        --with-sqlite3
+        --with-readline
+        --with-sodium
+        --enable-gd
+        --with-freetype
+        --with-jpeg
+        --with-webp
+      linux: >-
+        --with-pdo-pgsql
+        --with-pgsql
+  "8.5":
+    bundled_extensions:
+      - calendar
+      - core
+      - ctype
+      - date
+      - exif
+      - ffi
+      - fileinfo
+      - filter
+      - ftp
+      - gettext
+      - hash
+      - iconv
+      - json
+      - lexbor
+      - libxml
+      - openssl
+      - pcntl
+      - pcre
+      - pdo
+      - phar
+      - posix
+      - random
+      - readline
+      - reflection
+      - session
+      - shmop
+      - sockets
+      - sodium
+      - spl
+      - standard
+      - sysvmsg
+      - sysvsem
+      - sysvshm
+      - tokenizer
+      - uri
+      - opcache
+      - zlib
 smoke:
   - "php -v"
   - "php -m"

--- a/cmd/phpup/main.go
+++ b/cmd/phpup/main.go
@@ -226,21 +226,31 @@ func main() {
 //   - if the user wrote "none" in extensions (ExtensionsReset), every bundled
 //     extension not in their explicit include list.
 //
+// Include wins: a name that appears in p.Extensions is never added to the
+// disabled set — not from ExtensionsExclude (e.g. `extensions: redis, :redis`
+// is a contradiction that resolves to "redis stays enabled") nor from the
+// reset-minus-include logic.
+//
 // Sorted output ensures deterministic filesystem ordering across runs.
 func computeDisabledExtensions(p *plan.Plan, bundled []string) []string {
+	included := map[string]bool{}
+	for _, name := range p.Extensions {
+		included[name] = true
+	}
+
 	disabled := map[string]bool{}
 	for _, name := range p.ExtensionsExclude {
+		if included[name] {
+			continue // include wins
+		}
 		disabled[name] = true
 	}
 	if p.ExtensionsReset {
-		included := map[string]bool{}
-		for _, name := range p.Extensions {
-			included[name] = true
-		}
 		for _, name := range bundled {
-			if !included[name] {
-				disabled[name] = true
+			if included[name] {
+				continue
 			}
+			disabled[name] = true
 		}
 	}
 	if len(disabled) == 0 {

--- a/cmd/phpup/main.go
+++ b/cmd/phpup/main.go
@@ -61,9 +61,15 @@ func main() {
 		log.Fatalf("parse embedded lockfile: %v", err)
 	}
 
-	// 3. Build minimal catalog for resolution
+	// 3. Build minimal catalog for resolution. The runtime keys the Versions
+	// map by the exact PHPVersion that resolve.Resolve will look up, so the
+	// per-version bundled list is always found for IsBundled.
 	cat := &catalog.Catalog{
-		PHP: &catalog.PHPSpec{BundledExtensions: compat.BundledExtensions(p.PHPVersion)},
+		PHP: &catalog.PHPSpec{
+			Versions: map[string]*catalog.PHPVersionSpec{
+				p.PHPVersion: {BundledExtensions: compat.BundledExtensions(p.PHPVersion)},
+			},
+		},
 		Extensions: map[string]*catalog.ExtensionSpec{
 			"redis":  {Name: "redis", Kind: catalog.ExtensionKindPECL, Versions: []string{"6.2.0"}},
 			"xdebug": {Name: "xdebug", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.5.1"}, Ini: []string{"zend_extension=xdebug", "xdebug.mode=coverage"}},

--- a/cmd/phpup/main.go
+++ b/cmd/phpup/main.go
@@ -63,11 +63,15 @@ func main() {
 
 	// 3. Build minimal catalog for resolution. The runtime keys the Versions
 	// map by the exact PHPVersion that resolve.Resolve will look up, so the
-	// per-version bundled list is always found for IsBundled.
+	// per-version bundled list is always found for IsBundled. The list is
+	// the UNION of v2's baseline (compat.BundledExtensions) and our bundle's
+	// extras (compat.OurBuildBundledExtras) — the latter reflects configure
+	// flags our current 8.4 core has beyond v2's slim set.
+	bundled := append(compat.BundledExtensions(p.PHPVersion), compat.OurBuildBundledExtras(p.PHPVersion)...)
 	cat := &catalog.Catalog{
 		PHP: &catalog.PHPSpec{
 			Versions: map[string]*catalog.PHPVersionSpec{
-				p.PHPVersion: {BundledExtensions: compat.BundledExtensions(p.PHPVersion)},
+				p.PHPVersion: {BundledExtensions: bundled},
 			},
 		},
 		Extensions: map[string]*catalog.ExtensionSpec{
@@ -204,7 +208,7 @@ func main() {
 	}
 
 	// 10. Write disable fragments for excluded / reset-implied extensions.
-	for _, name := range computeDisabledExtensions(p, compat.BundledExtensions(p.PHPVersion)) {
+	for _, name := range computeDisabledExtensions(p, bundled) {
 		if err := compose.WriteDisableExtension(layout.ConfDir, name); err != nil {
 			log.Fatalf("write disable fragment for %s: %v", name, err)
 		}
@@ -275,15 +279,15 @@ func computeDisabledExtensions(p *plan.Plan, bundled []string) []string {
 // if execution fails (non-zero exit, unexpected output, etc.) — better to
 // surface a less-specific version than to abort a successful install.
 //
-// We invoke the literal command name "php" and set cmd.Dir + cmd.Env so that
-// gosec's taint analysis does not flag the subprocess call — the executable
-// name is a compile-time constant, not a tainted path.
+// The absolute path is constructed from layout.BinDir (runtime-owned, not
+// user input). An earlier PATH-prepend attempt was dropped because duplicate
+// PATH entries in cmd.Env caused glibc to resolve "php" to the system binary
+// instead of the composed one.
 func resolvePHPVersion(layout *compose.Layout, requested string) string {
-	cmd := exec.Command("php", "-v")
-	cmd.Env = append(os.Environ(), "PATH="+layout.BinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	out, err := cmd.Output()
+	phpBin := filepath.Join(layout.BinDir, "php")
+	out, err := exec.Command(phpBin, "-v").Output() //nolint:gosec // G204 false positive: phpBin is filepath.Join(layout.BinDir, "php"); layout.BinDir is runtime-composed, not user input
 	if err != nil {
-		log.Printf("WARNING: failed to run php -v from %s: %v; using requested %q as output", layout.BinDir, err, requested)
+		log.Printf("WARNING: failed to run %s -v: %v; using requested %q as output", phpBin, err, requested)
 		return requested
 	}
 	line := strings.SplitN(string(out), "\n", 2)[0]

--- a/cmd/phpup/main.go
+++ b/cmd/phpup/main.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/buildrush/setup-php/internal/cache"
 	"github.com/buildrush/setup-php/internal/catalog"
+	"github.com/buildrush/setup-php/internal/compat"
 	"github.com/buildrush/setup-php/internal/compose"
 	"github.com/buildrush/setup-php/internal/env"
 	"github.com/buildrush/setup-php/internal/extract"
@@ -22,15 +26,6 @@ import (
 
 //go:embed bundles.lock
 var embeddedLockfile []byte
-
-var bundledExtensions = []string{
-	"mbstring", "curl", "intl", "zip", "json", "pdo", "pdo_mysql",
-	"pdo_sqlite", "sqlite3", "tokenizer", "xml", "dom", "simplexml",
-	"xmlreader", "xmlwriter", "ctype", "filter", "hash", "iconv",
-	"session", "bcmath", "calendar", "exif", "ftp", "soap", "sockets",
-	"sodium", "gd", "readline", "openssl", "zlib", "opcache",
-	"pgsql", "pdo_pgsql",
-}
 
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "--version" {
@@ -47,6 +42,14 @@ func main() {
 	}
 	p.ApplyCoverage()
 
+	// Emit warnings for inputs that cannot be implemented given our architecture.
+	if p.Update {
+		fmt.Fprintln(os.Stderr, compat.UnimplementedInputWarning("update", "true"))
+	}
+	if p.IniFile != "production" {
+		fmt.Fprintln(os.Stderr, compat.UnimplementedInputWarning("ini-file", p.IniFile))
+	}
+
 	if p.Verbose {
 		log.Printf("Plan: PHP %s, extensions=%v, os=%s, arch=%s, ts=%s, coverage=%s",
 			p.PHPVersion, p.Extensions, p.OS, p.Arch, p.ThreadSafety, p.Coverage)
@@ -60,7 +63,7 @@ func main() {
 
 	// 3. Build minimal catalog for resolution
 	cat := &catalog.Catalog{
-		PHP: &catalog.PHPSpec{BundledExtensions: bundledExtensions},
+		PHP: &catalog.PHPSpec{BundledExtensions: compat.BundledExtensions(p.PHPVersion)},
 		Extensions: map[string]*catalog.ExtensionSpec{
 			"redis":  {Name: "redis", Kind: catalog.ExtensionKindPECL, Versions: []string{"6.2.0"}},
 			"xdebug": {Name: "xdebug", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.5.1"}, Ini: []string{"zend_extension=xdebug", "xdebug.mode=coverage"}},
@@ -92,10 +95,11 @@ func main() {
 			log.Printf("Cache hit at %s", hit.Path)
 		}
 		layout := layoutFromDir(hit.Path)
-		if err := exportEnv(layout, p.PHPVersion); err != nil {
+		resolved := resolvePHPVersion(layout, p.PHPVersion)
+		if err := exportEnv(layout, resolved); err != nil {
 			log.Fatalf("export env: %v", err)
 		}
-		fmt.Printf("PHP %s ready (cached)\n", p.PHPVersion)
+		fmt.Printf("PHP %s ready (cached)\n", resolved)
 		return
 	}
 
@@ -188,22 +192,91 @@ func main() {
 		log.Fatalf("compose: %v", err)
 	}
 
-	// 9. Write user ini values
-	if err := compose.WriteIniValues(layout.ConfDir, p.IniValues); err != nil {
+	// 9. Write ini values: compat defaults first, then user overrides on top.
+	if err := compose.WriteIniValuesWithDefaults(layout.ConfDir, compat.DefaultIniValues(p.PHPVersion), p.IniValues); err != nil {
 		log.Fatalf("write ini values: %v", err)
 	}
 
-	// 10. Export env
-	if err := exportEnv(layout, p.PHPVersion); err != nil {
+	// 10. Write disable fragments for excluded / reset-implied extensions.
+	for _, name := range computeDisabledExtensions(p, compat.BundledExtensions(p.PHPVersion)) {
+		if err := compose.WriteDisableExtension(layout.ConfDir, name); err != nil {
+			log.Fatalf("write disable fragment for %s: %v", name, err)
+		}
+	}
+
+	// 11. Export env
+	resolved := resolvePHPVersion(layout, p.PHPVersion)
+	if err := exportEnv(layout, resolved); err != nil {
 		log.Fatalf("export env: %v", err)
 	}
 
-	// 11. Seed cache
+	// 12. Seed cache
 	if err := store.Seed(planHash, baseDir); err != nil {
 		log.Printf("WARNING: failed to seed cache: %v", err)
 	}
 
-	fmt.Printf("PHP %s ready\n", p.PHPVersion)
+	fmt.Printf("PHP %s ready\n", resolved)
+}
+
+// computeDisabledExtensions returns the sorted list of extensions that should
+// be disabled via conf.d fragments given the user's plan and the bundled
+// extension set for the requested PHP version. The returned set is the union
+// of:
+//   - explicit ":ext" exclusions, and
+//   - if the user wrote "none" in extensions (ExtensionsReset), every bundled
+//     extension not in their explicit include list.
+//
+// Sorted output ensures deterministic filesystem ordering across runs.
+func computeDisabledExtensions(p *plan.Plan, bundled []string) []string {
+	disabled := map[string]bool{}
+	for _, name := range p.ExtensionsExclude {
+		disabled[name] = true
+	}
+	if p.ExtensionsReset {
+		included := map[string]bool{}
+		for _, name := range p.Extensions {
+			included[name] = true
+		}
+		for _, name := range bundled {
+			if !included[name] {
+				disabled[name] = true
+			}
+		}
+	}
+	if len(disabled) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(disabled))
+	for name := range disabled {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// resolvePHPVersion runs `php -v` against the composed binary and parses the
+// full X.Y.Z version from the first line. Falls back to the requested version
+// if execution fails (non-zero exit, unexpected output, etc.) — better to
+// surface a less-specific version than to abort a successful install.
+//
+// We invoke the literal command name "php" and set cmd.Dir + cmd.Env so that
+// gosec's taint analysis does not flag the subprocess call — the executable
+// name is a compile-time constant, not a tainted path.
+func resolvePHPVersion(layout *compose.Layout, requested string) string {
+	cmd := exec.Command("php", "-v")
+	cmd.Env = append(os.Environ(), "PATH="+layout.BinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.Output()
+	if err != nil {
+		log.Printf("WARNING: failed to run php -v from %s: %v; using requested %q as output", layout.BinDir, err, requested)
+		return requested
+	}
+	line := strings.SplitN(string(out), "\n", 2)[0]
+	// Expected: "PHP 8.4.5 (cli) (built: ...)"
+	fields := strings.Fields(line)
+	if len(fields) >= 2 && fields[0] == "PHP" {
+		return fields[1]
+	}
+	return requested
 }
 
 func layoutFromDir(dir string) *compose.Layout {

--- a/cmd/phpup/main_test.go
+++ b/cmd/phpup/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/buildrush/setup-php/internal/plan"
+)
+
+func TestComputeDisabledExtensions(t *testing.T) {
+	tests := []struct {
+		name    string
+		p       plan.Plan
+		bundled []string
+		want    []string
+	}{
+		{
+			name:    "plain excludes",
+			p:       plan.Plan{ExtensionsExclude: []string{"opcache", "xml"}},
+			bundled: []string{"curl", "opcache", "xml"},
+			want:    []string{"opcache", "xml"},
+		},
+		{
+			name:    "reset disables all bundled not in include",
+			p:       plan.Plan{Extensions: []string{"curl"}, ExtensionsReset: true},
+			bundled: []string{"curl", "opcache", "xml"},
+			want:    []string{"opcache", "xml"},
+		},
+		{
+			name:    "reset with explicit exclude union",
+			p:       plan.Plan{Extensions: []string{"curl"}, ExtensionsExclude: []string{"foo"}, ExtensionsReset: true},
+			bundled: []string{"curl", "opcache"},
+			want:    []string{"foo", "opcache"},
+		},
+		{
+			name:    "no reset, no excludes gives empty",
+			p:       plan.Plan{Extensions: []string{"redis"}},
+			bundled: []string{"curl", "opcache"},
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeDisabledExtensions(&tt.p, tt.bundled)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/cmd/phpup/main_test.go
+++ b/cmd/phpup/main_test.go
@@ -37,6 +37,18 @@ func TestComputeDisabledExtensions(t *testing.T) {
 			bundled: []string{"curl", "opcache"},
 			want:    nil,
 		},
+		{
+			name:    "include wins over explicit exclude (redis, :redis)",
+			p:       plan.Plan{Extensions: []string{"redis"}, ExtensionsExclude: []string{"redis"}},
+			bundled: []string{"curl", "opcache"},
+			want:    nil,
+		},
+		{
+			name:    "reset with include overlap does not disable included",
+			p:       plan.Plan{Extensions: []string{"curl", "opcache"}, ExtensionsReset: true},
+			bundled: []string{"curl", "opcache", "mbstring"},
+			want:    []string{"mbstring"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -1,0 +1,451 @@
+# shivammathur/setup-php@v2 Compatibility Matrix
+
+This document is the authoritative baseline for what `buildrush/setup-php` must
+accept, default, and produce in order to serve as a drop-in replacement for
+`shivammathur/setup-php@v2`. Every row cites a specific source line or package
+so a later task encoding the behavior in Go can verify the value.
+
+## Pinning
+
+| Field | Value |
+| --- | --- |
+| Upstream repo | `shivammathur/setup-php` |
+| Ref | annotated tag `v2` |
+| Tag object | `728c6c6b8cf02c2e48117716a91ee48313958a19` |
+| Commit SHA (dereferenced) | `accd6127cb78bee3e8082180cb391013d204ef9f` |
+| Commit authored | `2026-03-15T16:14:02Z` |
+| Commit message | `Update dependencies` |
+| `ondrej/php` PPA, release URL | https://launchpad.net/~ondrej/+archive/ubuntu/php |
+| PPA snapshot `Date:` observed (Ubuntu 24.04 noble `InRelease`) | `Sat, 11 Apr 2026 10:46:03 UTC` |
+| Audit date | `2026-04-17` |
+
+Throughout this document `<SHA>` refers to
+`accd6127cb78bee3e8082180cb391013d204ef9f` and `<PPA_DATE>` refers to
+`2026-04-11`.
+
+Raw source root:
+`https://raw.githubusercontent.com/shivammathur/setup-php/<SHA>/`
+
+---
+
+## 1. Inputs
+
+### 1.1 `action.yml` declared inputs
+
+Source: `action.yml` @ `<SHA>` (lines 1-38).
+
+| Input | Required | Default | Description (verbatim) | Source |
+| --- | --- | --- | --- | --- |
+| `php-version` | false | *(unset)* | `Setup PHP version.` | `action.yml` L8-10 |
+| `php-version-file` | false | *(unset)* | `Setup PHP version from a file.` | `action.yml` L11-13 |
+| `extensions` | false | *(unset)* | `Setup PHP extensions.` | `action.yml` L14-16 |
+| `ini-file` | false | `production` | `Set base ini file.` | `action.yml` L17-20 |
+| `ini-values` | false | *(unset)* | `Add values to php.ini.` | `action.yml` L21-23 |
+| `coverage` | false | *(unset)* | `Setup code coverage driver.` | `action.yml` L24-26 |
+| `tools` | false | *(unset)* | `Setup popular tools globally.` | `action.yml` L27-29 |
+| `github-token` | *(unspecified)* | `${{ github.token }}` | `GitHub token to use for authentication.` | `action.yml` L30-32 |
+
+Notes:
+
+- `action.yml` L20 sets `ini-file` default to `'production'`; `src/utils.ts`
+  `parseIniFile` (L88-97) additionally accepts `development`, `none`,
+  `php.ini-production` and `php.ini-development`, and falls back to
+  `production` for everything else.
+- `src/utils.ts` `parseVersion` (L63-81) treats `latest`, `lowest`, `highest`,
+  `nightly`, `master` and the pattern `<digit>.x` as manifest lookups against
+  `src/configs/php-versions.json`. Any other value >=2 chars is truncated to
+  its first three characters (e.g. `8.4.3` → `8.4`); single-char numeric
+  input becomes `<n>.0`.
+- `src/install.ts` L37 runs `getScript`; the default `ini-file` value
+  `production` is what ultimately passes into `configure_php` in
+  `src/scripts/linux.sh`.
+
+### 1.2 Env-var-driven inputs (not declared in `action.yml`)
+
+`src/utils.ts` `getInput` (L30-46) first consults `core.getInput(name)` and
+falls back to `readEnv(name)` (L11-22), which probes
+`$NAME`, `$name`, `$NAME_UPPER`, `$name-with-dashes`, `$NAME-WITH-DASHES`.
+In addition, `src/scripts/unix.sh` `read_env` (L52-85) consumes several
+lowercase/uppercase flag pairs directly. The following are supported but not
+exposed in `action.yml`:
+
+| Variable (primary) | Aliases | Semantics | Default | Source |
+| --- | --- | --- | --- | --- |
+| `fail-fast` / `fail_fast` | `FAIL_FAST` | If `true`, `add_log` aborts on any `✗` row. | `false` | `src/install.ts` L54; `src/scripts/unix.sh` L38, L56, L79 |
+| `update` | `UPDATE` | Force-update PHP to latest patch. | `false` (auto `true` if Ondrej PPA is missing on a GitHub-hosted Ubuntu runner, `src/scripts/unix.sh` L69-77). | `src/scripts/unix.sh` L53, L71, L73, L81 |
+| `debug` | `DEBUG` | `true` → install `-dbgsym` packages and `update=true`. | `false` | `src/scripts/unix.sh` L54; `src/scripts/linux.sh` L98, L203-205 |
+| `phpts` | `PHPTS` | `ts` / `zts` → install thread-safe build (also forces `update=true`). | `nts` | `src/scripts/unix.sh` L55 |
+| `runner` | `RUNNER` | Overrides auto-detected `github` / `self-hosted`. | `github` on GitHub Actions image, else `self-hosted`. | `src/scripts/unix.sh` L57-67 |
+| `setup_php_tools_dir` | `SETUP_PHP_TOOLS_DIR` | Where tool shims are placed. | `/usr/local/bin` | `src/scripts/unix.sh` L61 |
+| `setup_php_tool_cache_dir` | `SETUP_PHP_TOOL_CACHE_DIR` | Where downloaded tools are cached. | `${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}/setup-php/tools` | `src/scripts/unix.sh` L62 |
+| `GITHUB_TOKEN` | — | Consumed verbatim; `src/install.ts` L55 sets it from the `github-token` input if unset. | *(populated)* | `src/install.ts` L55 |
+| `COMPOSER_PROJECT_DIR` | — | Directory searched for `composer.lock` / `composer.json` when no explicit version is supplied. | `""` (cwd via `path.join`) | `src/utils.ts` L454-480 |
+| `COMPOSER_TOKEN` | — | Preferred over `GITHUB_TOKEN` for Composer's GitHub OAuth; `setup-php` writes it to `auth.json`. Documented as deprecated but still honored. | *(unset)* | `src/scripts/tools/add_tools.sh` L86; `src/tools.ts` L113; README L817 |
+| `PACKAGIST_TOKEN` | — | Private Packagist http-basic password, written to `auth.json`. | *(unset)* | `src/scripts/tools/add_tools.sh` L83-84; README L823 |
+| `COMPOSER_AUTH_JSON` | — | Raw JSON blob tee'd into `$COMPOSER_HOME/auth.json`. | *(unset)* | `src/scripts/tools/add_tools.sh` L75-81; README L836 |
+| `COMPOSER_PROCESS_TIMEOUT` | — | Overwrites the bundled `composer.env` default (`0`). | `0` | `src/scripts/tools/add_tools.sh` L104-107; `src/configs/composer.env` |
+| `COMPOSER_ALLOW_PLUGINS` | — | Comma list of plugin package globs; each is set to `allow-plugins.<pkg>=true` via `composer global config`. | *(unset)* | `src/scripts/tools/add_tools.sh` L109-111 |
+| `RUNNER_TOOL_CACHE` | — | Reassigned to `/opt/hostedtoolcache` for self-hosted runners. | GitHub Actions sets it. | `src/scripts/unix.sh` L228 |
+| `ImageOS`, `ImageVersion`, `RUNNER_ENVIRONMENT`, `ACT`, `CONTAINER` | — | Heuristics for self-hosted detection. | *(GitHub sets or unset)* | `src/scripts/unix.sh` L57-59 |
+
+`src/configs/composer.env` unconditionally exports the following to
+`$GITHUB_ENV` / the profile (see `add_env_path` in `src/scripts/unix.sh`
+L187-196 and `configure_composer` in `add_tools.sh`):
+
+```
+COMPOSER_PROCESS_TIMEOUT=0
+COMPOSER_NO_INTERACTION=1
+COMPOSER_NO_AUDIT=1
+```
+
+`COMPOSER_ALLOW_SUPERUSER` is **not** exported by v2 (grep confirmed absent
+from `src/scripts/**`). The plan mentions it as a candidate; we record its
+absence explicitly so downstream tasks do not assume otherwise.
+
+### 1.3 Outputs
+
+| Output | Value | Source |
+| --- | --- | --- |
+| `php-version` | PHP version in semver (e.g. `8.4.20`), via `set_output "php-version" "$semver"`. | `action.yml` L33-35; `src/scripts/linux.sh` L326; `src/scripts/unix.sh` L260-262 |
+
+### 1.4 Precedence rules for `php-version`
+
+From `src/utils.ts` `readPHPVersion` (L437-483):
+
+1. `php-version` input (if non-empty).
+2. The file named by `php-version-file`, or `.php-version` if that input is
+   empty. The file is parsed with the regex `^(?:php\s)?(\d+\.\d+\.\d+)$`
+   (i.e. plain version or leading `php ` — compatible with `asdf`'s
+   `.tool-versions`); if the regex does not match the file's raw trimmed
+   content is returned.
+3. If `php-version-file` was explicitly set but the file does not exist,
+   `throw new Error("Could not find '${versionFile}' file.")`.
+4. `${COMPOSER_PROJECT_DIR}/composer.lock` → `platform-overrides.php`.
+5. `${COMPOSER_PROJECT_DIR}/composer.json` → `config.platform.php`.
+6. Fallback literal `latest` (resolved via `src/configs/php-versions.json`
+   manifest in `parseVersion`, L63-81).
+
+---
+
+## 2. Default `php.ini` values applied on Linux
+
+`src/scripts/unix.sh` `configure_php` (L247-257) is called unconditionally
+from `src/scripts/linux.sh` `setup_php` (L325). It concatenates
+`src/configs/ini/php.ini` into every `php.ini` file discovered under
+`$ini_dir/..` (i.e. every SAPI). It additionally appends
+`src/configs/ini/xdebug.ini` when the PHP version matches
+`xdebug3_versions` (`7.[2-4]|8.[0-9]`) and
+`src/configs/ini/jit.ini` (or `jit_aarch64.ini` on arm64/aarch64) to the
+per-SAPI `99-pecl.ini` scan-dir file when the version matches
+`jit_versions` (`8.[0-9]`).
+
+### 2.1 `src/configs/ini/php.ini` (unconditional on Linux/Darwin)
+
+| Key | Value | Source |
+| --- | --- | --- |
+| `date.timezone` | `UTC` | `src/configs/ini/php.ini` L1 |
+| `memory_limit` | `-1` | `src/configs/ini/php.ini` L2 |
+
+### 2.2 `src/configs/ini/xdebug.ini` (applied when PHP version matches `7.[2-4]|8.[0-9]`)
+
+| Key | Value | Condition | Source |
+| --- | --- | --- | --- |
+| `xdebug.mode` | `coverage` | Version matches `xdebug3_versions` — PHP 7.2 through 8.9. | `src/configs/ini/xdebug.ini` L1; `src/scripts/unix.sh` L9, L254 |
+
+Note: this line is written even if xdebug is not installed. It is a no-op in
+that case because PHP ignores ini keys for unloaded extensions.
+
+### 2.3 `src/configs/ini/jit.ini` (applied when PHP version matches `8.[0-9]`)
+
+| Key | Value | Condition | Source |
+| --- | --- | --- | --- |
+| `opcache.enable` | `1` | PHP 8.0–8.9 (`jit_versions` regex). | `src/configs/ini/jit.ini` L1; `src/scripts/unix.sh` L8, L256 |
+| `opcache.jit_buffer_size` | `256M` | PHP 8.0–8.9. | `src/configs/ini/jit.ini` L2 |
+| `opcache.jit` | `1235` | PHP 8.0–8.9. | `src/configs/ini/jit.ini` L3 |
+
+The JIT block is written to `$pecl_file` (`$scan_dir/99-pecl.ini`) — not to
+the main `php.ini` — so user `ini-values` applied later (which tee into
+`${pecl_file:-${ini_file[@]}}`, per `src/config.ts` L20) override or append on
+top of it.
+
+### 2.4 `src/configs/ini/jit_aarch64.ini` (arm64/aarch64 only)
+
+Not fetched in this audit because PHP 8+ aarch64 ini content diverges (the
+upstream file sets `opcache.jit=off` for some PHP×arch combinations). **Gap**:
+confirm contents of `src/configs/ini/jit_aarch64.ini` before encoding in Go.
+Link:
+https://raw.githubusercontent.com/shivammathur/setup-php/accd6127cb78bee3e8082180cb391013d204ef9f/src/configs/ini/jit_aarch64.ini
+
+### 2.5 Base ini file selection
+
+`src/scripts/linux.sh` `add_php_config` (L264-283):
+
+- `production` (default): copies `php.ini-production` over every SAPI
+  `php.ini`. If `php.ini-production.cli` exists in `/usr/lib/php/<ver>/` it
+  also overwrites the CLI-scoped `php.ini`.
+- `development`: copies `php.ini-development`.
+- `none`: truncates every SAPI `php.ini` to empty.
+- The chosen mode is recorded in `/usr/lib/php/<ver>/php.ini-current` so
+  repeated invocations are idempotent.
+
+### 2.6 Extension-priority overrides
+
+`src/configs/mod_priority` maps extension names to the numeric prefix used
+when generating `/etc/php/<ver>/mods-available/<ext>.ini` files (the default
+priority is `20`, per `src/scripts/extensions/add_extensions.sh` L57). Content
+at `<SHA>`:
+
+| Extension | Priority | Notes |
+| --- | --- | --- |
+| `apc`, `apcu_bc`, `apcu-bc` | `25` | |
+| `blackfire`, `couchbase`, `decimal`, `ds`, `event`, `ev`, `grpc`, `inotify`, `maxminddb`, `mysqlnd_ms`, `protobuf`, `rdkafka`, `vips`, `zstd` | `30` | |
+| `http`, `pecl_http`, `pecl-http`, `mailparse`, `memcached`, `openswoole`, `swoole` | `25` / `30` (see file) | |
+| `libvirt-php` | `40` | |
+| `mysqlnd`, `opcache`, `pdo` | `10` | Must load early. |
+| `phalcon` | `35` | |
+| `psr`, `xml` | `15` | |
+| `pdo` | `10` | |
+
+Complete raw file: `src/configs/mod_priority` @ `<SHA>`.
+
+---
+
+## 3. Bundled extensions by PHP version (Ondrej PPA on Ubuntu 24.04 noble)
+
+Each list below is the exact output of `phpX.Y -m` after installing only
+`phpX.Y-cli` from `ppa:ondrej/php` inside a fresh `ubuntu:24.04` container on
+2026-04-17. The list is authoritative for what you get from a clean
+`phpX.Y-cli` install on noble — it does not include packages like `php-json`
+or `php-mbstring` which v2 commonly adds via `phpX.Y-<ext>` packages.
+
+The entries `[Zend Modules]` section contains only `Zend OPcache` for every
+version (reproduced once below).
+
+Methodology:
+
+```
+docker run --rm ubuntu:24.04 bash -c '
+  DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq software-properties-common ca-certificates
+  add-apt-repository -y ppa:ondrej/php
+  DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends phpX.Y-cli
+  phpX.Y -m
+  dpkg -s phpX.Y-cli | grep -E "^(Package|Version):"
+'
+```
+
+Raw capture files: `/tmp/v2/modules/php{8.1,8.2,8.3,8.4,8.5}.txt` (this
+workstation, regenerable at will).
+
+### 3.1 PHP 8.1 — package `8.1.34-3+ubuntu24.04.1+deb.sury.org+1`
+
+```
+calendar, Core, ctype, date, exif, FFI, fileinfo, filter, ftp, gettext, hash,
+iconv, json, libxml, openssl, pcntl, pcre, PDO, Phar, posix, readline,
+Reflection, session, shmop, sockets, sodium, SPL, standard, sysvmsg, sysvsem,
+sysvshm, tokenizer, Zend OPcache, zlib
+```
+
+### 3.2 PHP 8.2 — package `8.2.30-3+ubuntu24.04.1+deb.sury.org+1`
+
+```
+calendar, Core, ctype, date, exif, FFI, fileinfo, filter, ftp, gettext, hash,
+iconv, json, libxml, openssl, pcntl, pcre, PDO, Phar, posix, random, readline,
+Reflection, session, shmop, sockets, sodium, SPL, standard, sysvmsg, sysvsem,
+sysvshm, tokenizer, Zend OPcache, zlib
+```
+
+Delta vs 8.1: `+random` (core, PHP 8.2+).
+
+### 3.3 PHP 8.3 — package `8.3.30-3+ubuntu24.04.1+deb.sury.org+1`
+
+Same list as PHP 8.2 (identical `-m` output).
+
+### 3.4 PHP 8.4 — package `8.4.20-1+ubuntu24.04.1+deb.sury.org+1`
+
+Same list as PHP 8.3.
+
+### 3.5 PHP 8.5 — package `8.5.5-1+ubuntu24.04.1+deb.sury.org+1`
+
+```
+calendar, Core, ctype, date, exif, FFI, fileinfo, filter, ftp, gettext, hash,
+iconv, json, lexbor, libxml, openssl, pcntl, pcre, PDO, Phar, posix, random,
+readline, Reflection, session, shmop, sockets, sodium, SPL, standard, sysvmsg,
+sysvsem, sysvshm, tokenizer, uri, Zend OPcache, zlib
+```
+
+Delta vs 8.4: `+lexbor`, `+uri` (both new in PHP 8.5).
+
+### 3.6 Summary table
+
+| Extension | 8.1 | 8.2 | 8.3 | 8.4 | 8.5 |
+| --- | --- | --- | --- | --- | --- |
+| calendar | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Core | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ctype | ✓ | ✓ | ✓ | ✓ | ✓ |
+| date | ✓ | ✓ | ✓ | ✓ | ✓ |
+| exif | ✓ | ✓ | ✓ | ✓ | ✓ |
+| FFI | ✓ | ✓ | ✓ | ✓ | ✓ |
+| fileinfo | ✓ | ✓ | ✓ | ✓ | ✓ |
+| filter | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ftp | ✓ | ✓ | ✓ | ✓ | ✓ |
+| gettext | ✓ | ✓ | ✓ | ✓ | ✓ |
+| hash | ✓ | ✓ | ✓ | ✓ | ✓ |
+| iconv | ✓ | ✓ | ✓ | ✓ | ✓ |
+| json | ✓ | ✓ | ✓ | ✓ | ✓ |
+| lexbor | | | | | ✓ |
+| libxml | ✓ | ✓ | ✓ | ✓ | ✓ |
+| openssl | ✓ | ✓ | ✓ | ✓ | ✓ |
+| pcntl | ✓ | ✓ | ✓ | ✓ | ✓ |
+| pcre | ✓ | ✓ | ✓ | ✓ | ✓ |
+| PDO | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Phar | ✓ | ✓ | ✓ | ✓ | ✓ |
+| posix | ✓ | ✓ | ✓ | ✓ | ✓ |
+| random | | ✓ | ✓ | ✓ | ✓ |
+| readline | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Reflection | ✓ | ✓ | ✓ | ✓ | ✓ |
+| session | ✓ | ✓ | ✓ | ✓ | ✓ |
+| shmop | ✓ | ✓ | ✓ | ✓ | ✓ |
+| sockets | ✓ | ✓ | ✓ | ✓ | ✓ |
+| sodium | ✓ | ✓ | ✓ | ✓ | ✓ |
+| SPL | ✓ | ✓ | ✓ | ✓ | ✓ |
+| standard | ✓ | ✓ | ✓ | ✓ | ✓ |
+| sysvmsg | ✓ | ✓ | ✓ | ✓ | ✓ |
+| sysvsem | ✓ | ✓ | ✓ | ✓ | ✓ |
+| sysvshm | ✓ | ✓ | ✓ | ✓ | ✓ |
+| tokenizer | ✓ | ✓ | ✓ | ✓ | ✓ |
+| uri | | | | | ✓ |
+| Zend OPcache | ✓ | ✓ | ✓ | ✓ | ✓ |
+| zlib | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+Caveats:
+
+- The list is what `phpX.Y-cli` alone ships on Ubuntu 24.04 noble. Ondrej
+  builds for Debian and older Ubuntu series differ (e.g. some extensions are
+  shared packages on focal but built-in on noble). This audit intentionally
+  scopes to noble because that is what `ubuntu-latest` runners currently use.
+- v2 on GitHub-hosted runners typically starts from a pre-installed PHP whose
+  bundled set can exceed the above; this document is the Ondrej-only baseline
+  that `buildrush/setup-php` OCI bundles must match or exceed.
+
+---
+
+## 4. Extension-list syntax
+
+Source: `src/extensions.ts` (Linux branch `addExtensionLinux`, L244-353) and
+`src/utils.ts` `extensionArray` (L213-237).
+
+### 4.1 Tokenization
+
+`extensionArray` (L221-236) splits the csv, lowercases each entry, and then
+for non-source tokens strips the leading `:`/`php-`/`php_`/`none`/`zend ` and
+collapses `pdo-mysql-X` → `pdo-mysqlX` style prefixes via the regex
+`/^(:)?(php[-_]|none|zend )|(-[^-]*)-/`. If a literal `none` token appears
+anywhere in the csv it is hoisted to the front of the resulting array so
+`disable_all_shared` runs before any add_extension.
+
+### 4.2 Accepted tokens
+
+| Token shape | Effect on Linux | Code path (`src/extensions.ts`) |
+| --- | --- | --- |
+| `mbstring` (bare) | `add_extension mbstring extension` → `apt-get install phpX.Y-mbstring` with PECL fallback. | default branch, L350 |
+| `sqlite` | Rewritten to `sqlite3` and then enabled as bare. | L344-346 |
+| `pdo_mysql`, `pdo-mysql` | Routed through `add_pdo_extension mysql`; enables `mysqlnd` + `mysqli` + `pdo_mysql`. | L339-342 |
+| `pdo_firebird` / `pdo_dblib` / `pdo_sqlite` | `add_pdo_extension <db>` with special-casing for `firebird` (installs `libfbclient2`), `dblib` (→ `sybase`), `sqlite` (→ `sqlite3`). | L339-342; `src/scripts/linux.sh` L58-86 |
+| `:mbstring` | Disables extension after all adds run (collected into `remove_script`, appended last). | L260-262 |
+| `none` | Inserts `disable_all_shared` — truncates `extension=`/`zend_extension=` lines from all `php.ini` files and `99-pecl.ini`. | L264-266; `add_extensions.sh` L124-133 |
+| `ext-<semver>` (e.g. `xdebug-3.1.6`) | `add_pecl_extension xdebug 3.1.6 zend_extension`. | L317-323 |
+| `ext-<state>` where state ∈ `stable\|beta\|alpha\|devel\|snapshot\|rc\|preview` (e.g. `xdebug-beta`) | `add_unstable_extension xdebug beta zend_extension`. | L308-314 |
+| `ext-owner/repo@ref` or `ext-<url>://<host>/owner/repo@ref` (e.g. `amqp-git/php-amqp@master`) | `add_extension_from_source` — clones, patches, `phpize && make && make install`. | L268-270; `src/utils.ts` L418-432 |
+| `blackfire`, `blackfire-<semver>` | `customPackage` → sources `src/scripts/extensions/blackfire.sh`. | L282-305 |
+| `relay`, `relay-<semver>`, `relay-nightly` | Same (PHP 7.4–8.5 only). | L279-281 |
+| `couchbase`, `event`, `gearman`, `geos`, `ibm_db2`, `pdo_ibm`, `pdo_oci`, `oci8`, `http`, `pecl_http`, `pdo_firebird` | `customPackage` via matching per-extension script. | L288-290 |
+| `intl-<icu-version>` (e.g. `intl-74.2`, excluded on PHP 5.3–5.5) | `customPackage intl intl-74.2 linux` — sources `intl.sh`. | L291 |
+| `ioncube` | `customPackage` (PHP 5.3–8.5). | L292 |
+| `phalcon3` / `phalcon4` / `phalcon5` (version-gated) | `customPackage`. | L293 |
+| `sqlsrv`, `pdo_sqlsrv` (PHP 7+) | `customPackage sqlsrv`. | L296 |
+| `zephir_parser[-semver]` (PHP 7.0–8.5) | `customPackage`. | L297-299 |
+| `cubrid` / `pdo_cubrid` | `customPackage` (PHP 5.3–7.x only). | L285-287 |
+| `pcov` (PHP 5.3–7.0) | Logs "not supported" and skips. | L326-328 |
+| `xdebug2` (PHP 7.2–7.4) | Forces `add_pecl_extension xdebug 2.9.8 zend_extension`. | L330-337 |
+
+`src/utils.ts` `getExtensionPrefix` (L270-277) determines whether the
+extension is loaded with `extension=` or `zend_extension=`; extensions
+matching `/xdebug([2-3])?$|opcache|ioncube|eaccelerator/` use
+`zend_extension`, all others use `extension`.
+
+### 4.3 Transformation examples
+
+Input → resulting `add_*` calls (Linux, PHP 8.4):
+
+- `mbstring, intl` → `add_extension mbstring extension` + `add_extension intl extension`.
+- `mbstring, :opcache` → `add_extension mbstring extension` first, then at the
+  end `disable_extension opcache`.
+- `none, mbstring` → `disable_all_shared` hoisted first, then
+  `add_extension mbstring extension`.
+- `xdebug-3.3.1` → `add_pecl_extension xdebug 3.3.1 zend_extension`.
+- `xdebug-beta` → `add_unstable_extension xdebug beta zend_extension`.
+- `pdo_mysql` → `add_pdo_extension mysql` (which internally enables
+  `mysqlnd`, `mysqli`, `pdo_mysql`).
+- `blackfire-2.4.2` → source `src/scripts/extensions/blackfire.sh` then
+  `add_blackfire blackfire-2.4.2`.
+- `amqp-php-amqp/php-amqp@master` → `add_extension_from_source amqp https://github.com php-amqp php-amqp master extension`.
+- `sqlite` → rewritten to `sqlite3` and `add_extension sqlite3 extension`.
+
+### 4.4 `ini-values` csv parsing
+
+`src/utils.ts` `CSVArray` (L245-263) splits on commas outside balanced
+`"`/`'` pairs. It also auto-quotes RHS values containing bash-unsafe metachars
+(`?{}|&~![()^`), e.g. `xdebug.mode=develop,coverage` becomes
+`xdebug.mode='develop,coverage'`, and collapses `key=a=b` to `key='a=b'`. Each
+resulting line is tee'd into `${pecl_file:-${ini_file[@]}}` (a.k.a.
+`$scan_dir/99-pecl.ini`), per `src/config.ts` L17-22.
+
+---
+
+## 5. L5 Behavioral quirks beyond the input surface
+
+Disposition key:
+
+- **implement** — required for v2 parity in this slice.
+- **document** — will be a knowing deviation documented for users.
+- **follow-up** — deferred to a later issue/task; not in scope for this slice.
+
+| # | Quirk | Source | Disposition |
+| --- | --- | --- | --- |
+| 5.1 | **Composer auto-install**: `filterList` in `src/tools.ts` L223-239 unconditionally `unshift`s `composer` onto the tools list unless `tools: none` is explicitly passed (`addTools` L666-667). Result: every v2 run produces `/usr/local/bin/composer` and exports `$COMPOSER_HOME`. | `src/tools.ts` L223-239, L660-719 | **implement** |
+| 5.2 | **`tools: none` short-circuit**: when the sole token is literally `none`, `addTools` returns an empty string — no tools step, *including no composer install*. Important edge case for parity. | `src/tools.ts` L666-667 | **implement** |
+| 5.3 | **Composer env exports** (`src/configs/composer.env`): `COMPOSER_PROCESS_TIMEOUT=0`, `COMPOSER_NO_INTERACTION=1`, `COMPOSER_NO_AUDIT=1` are tee'd into `$GITHUB_ENV` by `add_env_path` so all subsequent steps inherit them. | `src/configs/composer.env`; `src/scripts/unix.sh` L187-196; `src/scripts/tools/add_tools.sh` `set_composer_env` L102-112 | **implement** |
+| 5.4 | **`COMPOSER_ALLOW_SUPERUSER` is _not_ set** by v2 (grepped absent). The plan's mention is defensive; record as "not required". | absence of grep match in `src/**` | **document** |
+| 5.5 | **Composer auth**: if `COMPOSER_AUTH_JSON` env is valid JSON, it overwrites `$COMPOSER_HOME/auth.json`. Else `PACKAGIST_TOKEN` adds an `http-basic: repo.packagist.com` entry and `COMPOSER_TOKEN` (fallback `GITHUB_TOKEN`) adds a `github-oauth: github.com` entry. | `src/scripts/tools/add_tools.sh` L73-100 | **follow-up** (later slice covers private-registry auth) |
+| 5.6 | **`coverage: none` side-effect**: disables both Xdebug and PCOV via `disableCoverage` which appends `:pcov:false, :xdebug:false` to the extensions pass. Even if the user did not ask for xdebug, v2 removes it from the loaded set. | `src/coverage.ts` L105-118, L144-145 | **implement** |
+| 5.7 | **`coverage: xdebug` side-effect**: auto-disables pcov and installs `xdebug` (mapping `xdebug3` → `xdebug` after version gating). Sets up `xdebug.mode=coverage` via the `xdebug.ini` default (§2.2). | `src/coverage.ts` L26-52, L138-143; `src/configs/ini/xdebug.ini` | **implement** |
+| 5.8 | **`coverage: pcov`**: auto-disables xdebug, installs pcov, writes `pcov.enabled=1` as an additional ini value. | `src/coverage.ts` L61-96 | **implement** |
+| 5.9 | **`xdebug2` alias**: on PHP 7.2–7.4 the token `xdebug2` is pinned to PECL `xdebug 2.9.8`. Attempting `xdebug2` on 8.x is rejected with a `✗` log (not fatal unless `fail-fast=true`). | `src/coverage.ts` L9-16; `src/extensions.ts` L330-337 | **follow-up** (phase 2 does not ship PHP < 8.1) |
+| 5.10 | **`fail-fast` mode**: when truthy, `add_log` exits `1` on the first `✗`. Otherwise errors are informational. | `src/scripts/unix.sh` L30-40 | **implement** |
+| 5.11 | **`update: true`**: forces an `apt-get install` of the latest patch even if a compatible PHP is already on the runner. Auto-enabled when `phpts=ts` or `debug=true`, or when `ppa:ondrej/php` is absent from a GitHub-hosted Ubuntu runner. | `src/scripts/unix.sh` L53-77; `src/scripts/linux.sh` `update_php`/`add_php` L216-242 | **document** (OCI bundles always provide a specific patch, so "update" maps to "pick a newer bundle tag" in our model) |
+| 5.12 | **`debug: true`**: installs `phpX.Y-<ext>-dbgsym` for every extension and forces `update=true`. | `src/scripts/linux.sh` L98, L203-205 | **follow-up** |
+| 5.13 | **`phpts: ts\|zts`**: switches to `setup_php_builder` from `shivammathur/php-builder` releases. | `src/scripts/unix.sh` L55; `src/scripts/linux.sh` L115-118, L229-236 | **follow-up** |
+| 5.14 | **Tool cache location**: `tool_path_dir` default `/usr/local/bin`; `tool_cache_path_dir` default `${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}/setup-php/tools`. Overridable via `setup_php_tools_dir` / `setup_php_tool_cache_dir`. | `src/scripts/unix.sh` L61-62 | **implement** |
+| 5.15 | **`php-version-file` precedence**: input > default `.php-version` > `${COMPOSER_PROJECT_DIR}/composer.lock#platform-overrides.php` > `${COMPOSER_PROJECT_DIR}/composer.json#config.platform.php` > literal `latest`. An explicitly named file that doesn't exist throws; the default `.php-version` being absent is non-fatal. `.php-version` parsing supports both raw `8.4.3` and the `asdf` `.tool-versions` shape `php 8.4.3`. | `src/utils.ts` L437-483 | **implement** |
+| 5.16 | **`php-version: pre-installed`**: detects `command -v php-config`, adopts that major.minor, and sets `update=false`. Missing pre-installed PHP + `pre-installed` + no `update=true` is a fatal error. | `src/scripts/unix.sh` `check_pre_installed` L233-244 | **follow-up** |
+| 5.17 | **`ini-file: none`**: truncates every SAPI `php.ini` to empty before the configured defaults (§2.1–2.3) are appended. Users expect a literally empty baseline on top of which the v2 defaults still land. | `src/scripts/linux.sh` L279-281 | **implement** |
+| 5.18 | **`$php_dir/php.ini-current` idempotency marker**: v2 records the selected `ini-file` mode so rerunning with the same mode is a no-op. | `src/scripts/linux.sh` L267-283 | **document** (our OCI model is stateless; not required) |
+| 5.19 | **Extension CSV preprocessing**: lowercase, strip `php-` / `php_` / `zend ` prefixes, hoist `none`, dedupe later via `enable_extension` guard. Users rely on being able to pass `Zend OPcache` → `opcache`. | `src/utils.ts` L213-237 | **implement** |
+| 5.20 | **PPA bootstrap**: `add_extension_helper` calls `add_ppa ondrej/php` before installing the apt package. On a container without the PPA (e.g. custom self-hosted), v2 adds the PPA automatically. Our OCI bundles bypass the PPA entirely. | `src/scripts/linux.sh` L97 | **document** |
+| 5.21 | **PECL fallback for unknown extensions**: if the matching `phpX.Y-<ext>` apt package does not exist, `add_extension_helper` falls through to `pecl_install`. Users rely on this for extensions not packaged by Ondrej. | `src/scripts/linux.sh` L99 | **follow-up** |
+| 5.22 | **Sponsor log line**: every run ends with `add_log tick setup-php https://setup-php.com/sponsor`. Pure cosmetics. | `src/install.ts` L42-43 | **document** (we do not replicate) |
+| 5.23 | **Default `date.timezone=UTC`, `memory_limit=-1`** on Linux (see §2.1). Users and downstream CI scripts commonly rely on these being present. | `src/configs/ini/php.ini` | **implement** |
+
+---
+
+## References
+
+- Pinned source root:
+  https://github.com/shivammathur/setup-php/tree/accd6127cb78bee3e8082180cb391013d204ef9f
+- Raw `action.yml`:
+  https://raw.githubusercontent.com/shivammathur/setup-php/accd6127cb78bee3e8082180cb391013d204ef9f/action.yml
+- Launchpad PPA:
+  https://launchpad.net/~ondrej/+archive/ubuntu/php
+- PPA `InRelease` date observed in this audit: `Sat, 11 Apr 2026 10:46:03 UTC`.

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -43,7 +43,7 @@ Source: `action.yml` @ `<SHA>` (lines 1-38).
 | `ini-values` | false | *(unset)* | `Add values to php.ini.` | `action.yml` L21-23 |
 | `coverage` | false | *(unset)* | `Setup code coverage driver.` | `action.yml` L24-26 |
 | `tools` | false | *(unset)* | `Setup popular tools globally.` | `action.yml` L27-29 |
-| `github-token` | *(unspecified)* | `${{ github.token }}` | `GitHub token to use for authentication.` | `action.yml` L30-32 |
+| `github-token` | false | `${{ github.token }}` | `GitHub token to use for authentication.` | `action.yml` L30-32 |
 
 Notes:
 
@@ -197,16 +197,14 @@ at `<SHA>`:
 
 | Extension | Priority | Notes |
 | --- | --- | --- |
-| `apc`, `apcu_bc`, `apcu-bc` | `25` | |
-| `blackfire`, `couchbase`, `decimal`, `ds`, `event`, `ev`, `grpc`, `inotify`, `maxminddb`, `mysqlnd_ms`, `protobuf`, `rdkafka`, `vips`, `zstd` | `30` | |
-| `http`, `pecl_http`, `pecl-http`, `mailparse`, `memcached`, `openswoole`, `swoole` | `25` / `30` (see file) | |
-| `libvirt-php` | `40` | |
 | `mysqlnd`, `opcache`, `pdo` | `10` | Must load early. |
-| `phalcon` | `35` | |
 | `psr`, `xml` | `15` | |
-| `pdo` | `10` | |
+| `apc`, `apcu_bc`, `apcu-bc`, `http`, `pecl_http`, `pecl-http`, `mailparse`, `memcached`, `openswoole`, `swoole` | `25` | |
+| `blackfire`, `couchbase`, `decimal`, `ds`, `event`, `ev`, `grpc`, `inotify`, `maxminddb`, `mysqlnd_ms`, `protobuf`, `rdkafka`, `vips`, `zstd` | `30` | |
+| `phalcon` | `35` | |
+| `libvirt-php` | `40` | |
 
-Complete raw file: `src/configs/mod_priority` @ `<SHA>`.
+Complete raw file: `https://raw.githubusercontent.com/shivammathur/setup-php/<SHA>/src/configs/mod_priority` (31 entries).
 
 ---
 

--- a/docs/superpowers/specs/2026-04-17-phase2-compat-slice-design.md
+++ b/docs/superpowers/specs/2026-04-17-phase2-compat-slice-design.md
@@ -1,0 +1,231 @@
+# Phase 2 — Compat-First Slice: Drop-In Parity with `shivammathur/setup-php@v2`
+
+**Status:** Design, awaiting implementation plan
+**Date:** 2026-04-17
+**Supersedes:** Nothing (first slice of Phase 2 per the phased implementation design)
+**Target release:** `v0.2.0-alpha.1`
+
+## 1. Summary
+
+Phase 2 of `buildrush/setup-php` is an umbrella for Linux matrix expansion (PHP 8.1–8.5, top-50 extensions, x86_64 + aarch64, ubuntu-22.04 + ubuntu-24.04). This document specifies **sub-project #1 of Phase 2**: a compat-first slice that lands drop-in compatibility with `shivammathur/setup-php@v2` for the single PHP version and architecture Phase 1 already builds (PHP 8.4 NTS, linux/x86_64, ubuntu-24.04), with the catalog restructured to encode per-version compat intent for 8.1–8.5 (without building them yet).
+
+The slice ships **before** matrix expansion so that users migrating from `shivammathur/setup-php@v2` get drop-in behavior as soon as they move to the versions/arches we cover, and so that the matrix-expansion slices that follow build against a compat-correct baseline rather than rebuilding to fix compat drift later.
+
+## 2. Goals & non-goals
+
+### Goals
+- Every input declared by `shivammathur/setup-php@v2` is declared in our `action.yml` with matching names, types, defaults, and required/optional flags.
+- Every input we act on behaves the same way theirs does, including special syntaxes (extension exclusion, reset, etc.) and search orders.
+- Defaults shivammathur applies on CI runners (ini-values, coverage, etc.) are applied by us unless the user overrides.
+- The PHP 8.4 core bundle is rebuilt so its compile-time bundled extension set matches the set `shivammathur/setup-php@v2` exposes on Linux (sourced from the Ondrej PPA build).
+- Inputs we cannot implement given our architecture (e.g. `update`) are accepted for parseability and emit a clear warning rather than failing.
+- The `tools` input continues to parse-and-warn in this slice; real tools support is Phase 3.
+- Compat decisions and deviations are documented in `docs/compat-matrix.md`.
+
+### Non-goals
+- Building additional PHP versions (8.1/8.2/8.3/8.5). They are encoded in the catalog but not built.
+- aarch64. Stays x86_64 only.
+- ubuntu-22.04. Stays ubuntu-24.04 only.
+- Top-50 extension expansion. Extension set stays at the current 4 PECL entries plus the rebuilt 8.4 built-ins.
+- Tool installation (composer, phpunit, phpstan, etc.) — Phase 3.
+- Tiered fallbacks — Phase 3.
+- Automated compat-harness workflow that diffs our behavior against `shivammathur/setup-php@v2` at runtime. This is a planned follow-up slice under the Phase 2 umbrella (see §8).
+- macOS/Windows — Phases 5/6.
+
+## 3. Source of truth
+
+Compat is audited against a pinned reference so the work is reproducible and drift is attributable:
+- `shivammathur/setup-php` — pinned to a specific commit SHA, captured in `docs/compat-matrix.md`. The audit reads `action.yml`, `README.md`, and `src/` (TypeScript sources that implement the scripts).
+- Ondrej PPA (`ppa:ondrej/php`) — pinned to a specific snapshot date, captured in `docs/compat-matrix.md`. Used to determine bundled-extension sets per PHP version.
+
+When the pinned references are bumped, changes to compat data require a deliberate PR whose description names the old and new SHA/snapshot.
+
+## 4. Compat layers in scope
+
+| Layer | Description | Scope in this slice |
+|-------|-------------|---------------------|
+| L1 | Input shape in `action.yml` (names, types, defaults) | Full — every v2 input declared |
+| L2 | Semantic compat on inputs we implement | Full — `php-version`, `php-version-file`, `extensions`, `ini-values`, `coverage` |
+| L3 | Default ini-values + per-version built-in extension sets | Full — defaults applied at runtime; 8.4 rebuilt; catalog encodes 8.1–8.5 |
+| L4 | Output compat (`php-version` string format) | Full |
+| L5 | Behavioral quirks (Composer auto-install, env var exports, etc.) | Audit fully; implement cheap quirks; remaining documented with follow-up tracking |
+
+## 5. Architecture
+
+### 5.1 Component layout
+
+```
+action.yml                         ← declare all v2 inputs (add phpts, update, fail-fast, …)
+src/index.js                       ← pass new INPUT_* env vars through to phpup (no logic)
+cmd/phpup/main.go                  ← emit no-op warnings early; set php-version output (X.Y.Z)
+internal/plan/                     ← parse new inputs; full extension-syntax compat
+internal/compat/          (new)    ← single source of truth for "what v2 does":
+                                      - DefaultIniValues(phpVersion) map[string]string
+                                      - BundledExtensions(phpVersion) []string
+                                      - UnimplementedInputWarning(name, value) string
+internal/resolve/                  ← phpts/fail-fast semantics
+internal/compose/                  ← merge compat default ini-values; honor :ext exclusions
+catalog/php.yaml                   ← restructure to versions: {8.1..8.5: {...}}; only 8.4 has sources
+builders/linux/build-php.sh        ← 8.4 rebuild with compat-matching configure flags
+docs/compat-matrix.md     (new)    ← per-input table, quirk catalog, pinned references
+test/smoke/compat.sh      (new)    ← end-to-end compat scenario against rebuilt 8.4
+```
+
+### 5.2 Data flow
+
+```
+action.yml inputs (all v2 keys declared)
+    → src/index.js (env pass-through)
+    → cmd/phpup/main.go
+        → emit warnings for unimplementable inputs
+    → internal/plan
+        → parse new fields (phpts, update, fail-fast, …)
+        → extension-syntax parser: :ext, none, mixed lists
+    → internal/resolve
+        → apply phpts semantics (zts → warn+fallback, or fail under fail-fast: true)
+        → apply fail-fast: true (promote warnings to errors)
+    → internal/extract (unchanged)
+    → internal/compose
+        → compat.DefaultIniValues merged in (user-supplied overrides)
+        → :ext exclusions produce disable-*.ini fragments
+    → internal/env (export, unchanged)
+    → output: php-version=X.Y.Z (full triple)
+```
+
+The `internal/compat` package is the **one place** where "what shivammathur does" lives. Other packages call into it. Compat drift → one-file change.
+
+### 5.3 `action.yml` input additions
+
+Inputs added in this slice (pending audit — this is the baseline from the vision doc):
+
+| Input | Default | Behavior in this slice |
+|-------|---------|------------------------|
+| `phpts` | `nts` | `nts` honored; `zts` → warn + fallback to NTS (error under `fail-fast: true`) |
+| `update` | `false` | Accepted, no-op, warn if `true` |
+| `fail-fast` | `false` | `true` promotes soft-fallback warnings to errors |
+
+Inputs already declared but audited for default/description parity: `php-version`, `extensions`, `ini-values`, `coverage`, `tools`, `php-version-file`.
+
+Any additional inputs discovered during the audit are added with the same pattern: declared with matching default, implemented semantically if cheap, otherwise no-op + warn.
+
+### 5.4 Extension special-syntax parser
+
+`internal/plan` extends its `extensions` parser to match shivammathur v2's accepted syntax. The authoritative list is extracted from their source during the audit; the expected cases are:
+
+- `redis, xdebug` — list of extensions to enable (existing behavior).
+- `:opcache` — exclude a built-in extension. Runtime generates a `conf.d/disable-opcache.ini` or equivalent so the composed PHP does not load it.
+- `none` — reset: start from an empty extension set. Any extensions listed *after* `none` are the complete set.
+- `none, redis, xdebug` — start empty, then add `redis` and `xdebug` (no built-ins loaded).
+- Case/whitespace handling matches theirs (trim, lower-case names).
+
+If the audit uncovers additional syntax (version pinning via `ext@version`, for example), each case either lands here or is documented as deferred in `compat-matrix.md`.
+
+### 5.5 `internal/compat` package
+
+Single file, exports three pure functions and a small set of package-level maps as data:
+
+```go
+// DefaultIniValues returns the ini key/value pairs that
+// shivammathur/setup-php@v2 sets on Linux CI runners by default.
+// User-supplied ini-values take precedence over these.
+func DefaultIniValues(phpVersion string) map[string]string
+
+// BundledExtensions returns the set of extensions compiled-in to the
+// shivammathur/setup-php@v2 Linux build for a given PHP version
+// (i.e. what `php -m` reports after `setup-php` runs with no
+// `extensions:` input on Ondrej PPA's build for that version).
+// Used by the compose layer to determine what :ext exclusions
+// need to act on and what `none` needs to "reset from".
+func BundledExtensions(phpVersion string) []string
+
+// UnimplementedInputWarning returns the canonical warning line
+// (including the ::warning:: Actions prefix) emitted when a
+// no-op input is set to a non-default value.
+func UnimplementedInputWarning(inputName, value string) string
+```
+
+The per-version data lives in the same package as frozen Go maps. A companion `_test.go` file asserts the maps against golden files, so a change to compat data fails the test unless the golden is updated deliberately (forcing a reviewer to acknowledge the compat shift).
+
+### 5.6 Catalog restructure
+
+`catalog/php.yaml` moves from a single-version flat file to:
+
+```yaml
+# catalog/php.yaml
+versions:
+  "8.1":
+    bundled_extensions: [mbstring, curl, intl, zip, …]
+    # no sources: block ⇒ builder pipeline skips
+  "8.2":
+    bundled_extensions: [...]
+  "8.3":
+    bundled_extensions: [...]
+  "8.4":
+    bundled_extensions: [...]
+    sources:
+      version: 8.4.5
+      url: https://www.php.net/distributions/php-8.4.5.tar.xz
+      sha256: ...
+    abi_matrix:
+      - {os: linux, arch: x86_64, ts: nts}
+  "8.5":
+    bundled_extensions: [...]
+```
+
+- The planner (`cmd/planner/`) already operates on the catalog; its extension/PHP-core build matrix skips entries without `sources:`.
+- The extraction/compose runtime (`cmd/phpup/`) only consults `bundled_extensions` for the version actually in the lockfile, so catalog entries for unbuilt versions are inert at runtime.
+- This is a data-only change for 8.1/8.2/8.3/8.5; only 8.4 has a builder effect.
+
+### 5.7 PHP 8.4 rebuild
+
+`builders/linux/build-php.sh` is updated to pass the `./configure` flag set that produces a build with the same bundled extensions as `shivammathur/setup-php@v2` exposes on linux/x86_64. The diff between our current 8.4 build and the target is enumerated in `docs/compat-matrix.md` before implementation.
+
+The existing 4 PECL extension bundles (redis, xdebug, pcov, apcu) are rebuilt against the new 8.4 core if and only if the audit shows an ABI-affecting change. In most cases separately-loadable `.so` files remain compatible; the audit step confirms or denies.
+
+## 6. Error handling & warnings
+
+- **Unimplementable inputs** (`update`, possibly others from audit): accepted, no-op, emit `::warning::` line via `compat.UnimplementedInputWarning`. Warning text is asserted by tests so it stays stable across releases.
+- **Soft-fallback decisions** (ZTS requested but not built, extension unresolved, etc.): default to `::warning::` + fallback. Under `fail-fast: true`, each becomes a hard error with a matching `::error::` line.
+- **Parse errors on recognized inputs**: fail with matching wording where shivammathur fails; accept-and-ignore where they do.
+- **Compat-data test failure**: forces a deliberate golden-file update, which means a reviewer sees the shift in the PR diff.
+
+## 7. Testing strategy
+
+- **`internal/plan` tests**: full coverage of extension special syntax (exclusion, reset, mixed ordering, whitespace, case), and parsing of new inputs with all accepted values.
+- **`internal/compat` tests**: golden-file assertions on `DefaultIniValues` and `BundledExtensions` for each cataloged PHP version, plus exact warning-text assertion.
+- **`internal/compose` tests**: default-ini merge precedence (user beats compat), exclusion-fragment generation, interaction with `coverage: none`.
+- **`internal/resolve` tests**: `phpts: zts` warn/fallback path; `fail-fast: true` promotes the same scenarios to error.
+- **`cmd/phpup` integration**: a test that builds a fake plan with `update: true` + `tools: composer` and asserts both expected warning lines appear on `stderr`.
+- **Smoke (`test/smoke/compat.sh`)**: exercises `extensions: :opcache, redis`, `ini-values: memory_limit=256M,date.timezone=UTC`, `coverage: xdebug` end-to-end against the rebuilt 8.4 bundle. Asserts `php -m` includes redis and excludes opcache; `php --ini` shows the expected config path; `php -r 'echo ini_get("memory_limit");'` returns `256M`; xdebug module loaded.
+- **Existing tests**: untouched except where the plan/resolve/compose refactors intersect. Coverage target per `CLAUDE.md` (80%/package) must not regress.
+
+## 8. Follow-up slices (Phase 2 umbrella, out of this slice)
+
+Listed here so the overall Phase 2 shape is visible. Each gets its own spec → plan → impl cycle.
+
+1. **Compat harness (V2 verification)** — a CI workflow that runs fixture input matrices through both `shivammathur/setup-php@v2` and `buildrush/setup-php`, diffs `php -v` / `php -m` / `php --ini` / exported env / `$PATH` entries, fails on deviation. Can run once we have ≥2 PHP versions built so it's meaningful.
+2. **PHP 8.1–8.3, 8.5 builds on x86_64** — flip on the `sources:` block for each version, exercise the pipeline.
+3. **Extension matrix expansion to top-50** — catalog + build.
+4. **aarch64** — builder + abi_matrix + runner work.
+5. **ubuntu-22.04 runner coverage** — test matrix + any version-specific compat notes.
+6. **Phase 2 exit release** — `v0.2.0-alpha` (no `.1`) once (2)–(5) land.
+
+## 9. Release
+
+- Conventional commits throughout.
+- release-please cuts `v0.2.0-alpha.1` (or next appropriate alpha increment) when the compat slice merges.
+- README gets a "Compatibility with shivammathur/setup-php@v2" section linking to `docs/compat-matrix.md`.
+- A tracking issue (or discussion) lists deferred L5 quirks so they are visible to users and contributors.
+
+## 10. Open questions
+
+- **Exact list of v2 inputs** — settled by the audit; any input beyond the baseline (`php-version`, `extensions`, `ini-values`, `coverage`, `tools`, `php-version-file`, `phpts`, `update`, `fail-fast`) lands in `action.yml` with the same pattern.
+- **Ondrej PPA bundled-extension snapshot date** — chosen during implementation; pinned in `compat-matrix.md`.
+- **Warning phrasing** — drafted during implementation; asserted by tests.
+- **L5 quirk list** — produced by the audit; each quirk resolved to "implemented here", "documented deviation", or "follow-up issue #N".
+
+## 11. References
+
+- `docs/product-vision.md` — overall product rationale and compat targets.
+- `docs/superpowers/specs/2026-04-16-phased-implementation-design.md` — phase decomposition; this slice is sub-project #1 of Phase 2 (§4 of that doc).
+- `CLAUDE.md` — quality gates (must pass `make check`), commit style, coverage target.

--- a/docs/superpowers/specs/2026-04-17-phase2-t12-handoff.md
+++ b/docs/superpowers/specs/2026-04-17-phase2-t12-handoff.md
@@ -1,0 +1,167 @@
+# T12 Hand-off: Align PHP 8.4 Build with v2-Compat Bundled Set
+
+**Deferred from the Phase 2 compat-first slice.** Requires local Docker iteration; not suitable for autonomous execution. This document gives a precise, small-step recipe for when you're ready.
+
+## Goal
+
+Make the PHP 8.4 core bundle's compiled-in extension set a **superset** of `compat.BundledExtensions("8.4")` (the v2/Ondrej PPA baseline), so every extension a v2 user expects to be available on a clean `setup-php` run is available on our action too.
+
+Per the plan, subtractive changes are banned — our existing compiled set (mbstring, curl, intl, zip, soap, pdo_mysql, sqlite, gd, pgsql, bcmath) stays. We only **add** flags for v2-bundled extensions we don't currently compile.
+
+## Current vs. target
+
+Current `builders/linux/build-php.sh` produces (33 extensions after the `php -m` dedupe): the **fat set** historically in `catalog/php.yaml` pre-T11. Retain all of it.
+
+v2/Ondrej ships these 34 (lowercase, post-normalization):
+
+```
+calendar, core, ctype, date, exif, ffi, fileinfo, filter, ftp, gettext,
+hash, iconv, json, libxml, opcache, openssl, pcntl, pcre, pdo, phar,
+posix, random, readline, reflection, session, shmop, sockets, sodium,
+spl, standard, sysvmsg, sysvsem, sysvshm, tokenizer, zlib
+```
+
+Cross-referencing against what our current build produces (run `php -m` inside the current 8.4 bundle or consult pre-T11 `catalog/php.yaml`), these v2-bundled entries are **missing** from our compiled set:
+
+| Missing extension | Configure flag | Notes |
+|---|---|---|
+| `ffi` | `--with-ffi` | Foreign Function Interface; PHP 7.4+ |
+| `gettext` | `--with-gettext` | libc's gettext; needs no extra apt dep on Ubuntu |
+| `pcntl` | `--enable-pcntl` | Process control; POSIX-only, fine for Linux |
+| `posix` | `--enable-posix` | May already be default-on; adding flag is idempotent |
+| `shmop` | `--enable-shmop` | Shared-memory ops |
+| `sysvmsg` | `--enable-sysvmsg` | System V message queues |
+| `sysvsem` | `--enable-sysvsem` | System V semaphores |
+| `sysvshm` | `--enable-sysvshm` | System V shared memory |
+
+Extensions in the v2-bundled list that are **already present** in our build by default (no flag change needed): `calendar` ✓, `ctype` ✓, `date` (always-on), `exif` ✓, `fileinfo` (default on), `filter` (always-on), `ftp` ✓, `hash` (always-on), `iconv` (auto-detected), `json` (always-on since 8.0), `libxml` (pulled by xml), `opcache` ✓, `openssl` ✓, `pcre` (always-on), `pdo` (always-on), `phar` (on by default), `random` (PHP 8.2+ always-on), `readline` ✓, `reflection` (always-on), `session` (always-on), `sockets` ✓, `sodium` ✓, `spl` (always-on), `standard` (always-on), `tokenizer` (always-on), `zlib` ✓, `core` (always-on).
+
+## Concrete diff
+
+Apply to `builders/linux/build-php.sh`, inside the `./configure` invocation (currently lines 51–77):
+
+```diff
+ ./configure \
+   --prefix=/usr/local \
+   --enable-mbstring \
+   --with-curl \
+   --with-zlib \
+   --with-openssl \
+   --enable-bcmath \
+   --enable-calendar \
+   --enable-exif \
+   --enable-ftp \
+   --enable-intl \
+   --with-zip \
+   --enable-soap \
+   --enable-sockets \
+   --with-pdo-mysql \
+   --with-pdo-sqlite \
+   --with-sqlite3 \
+   --with-readline \
+   --with-sodium \
+   --enable-gd \
+   --with-freetype \
+   --with-jpeg \
+   --with-webp \
+   --with-pdo-pgsql \
+   --with-pgsql \
++  --with-ffi \
++  --with-gettext \
++  --enable-pcntl \
++  --enable-posix \
++  --enable-shmop \
++  --enable-sysvmsg \
++  --enable-sysvsem \
++  --enable-sysvshm \
+   --disable-cgi \
+   --enable-opcache
+```
+
+Also update the apt-get install list (currently line 33) to include FFI and gettext dev headers:
+
+```diff
+ $SUDO apt-get install -y -qq \
+   autoconf bison re2c pkg-config build-essential \
+   libicu-dev libcurl4-openssl-dev libzip-dev libsqlite3-dev \
+   libpq-dev libonig-dev libreadline-dev libsodium-dev \
+   libfreetype6-dev libjpeg-dev libwebp-dev libxml2-dev \
+-  zlib1g-dev libssl-dev gnupg2 xz-utils curl
++  zlib1g-dev libssl-dev gnupg2 xz-utils curl \
++  libffi-dev libgettextpo-dev
+```
+
+Mirror the same adds in `catalog/php.yaml` under `versions."8.4".configure_flags.common` so the planner's view matches the builder's reality.
+
+## Verification loop
+
+```bash
+# 1. Rebuild locally
+make bundle-php PHP_VERSION=8.4
+
+# 2. Unpack the produced bundle and introspect
+mkdir -p /tmp/inspect && tar -I zstd -xf /tmp/bundle.tar.zst -C /tmp/inspect
+/tmp/inspect/usr/local/bin/php -m | sort -f | tee /tmp/got.txt
+
+# 3. Derive the expected list — all lowercase, normalized
+go run ./scripts/dump_bundled 8.4 | sort > /tmp/want.txt  # one-off throwaway
+
+# 4. Diff
+diff /tmp/want.txt /tmp/got.txt
+```
+
+Expected outcome: every line in `/tmp/want.txt` appears in `/tmp/got.txt`. Extra lines in `/tmp/got.txt` (the documented deviations — mbstring, curl, intl, zip, soap, pdo_mysql, sqlite3, pdo_sqlite, gd, pdo_pgsql, pgsql, bcmath) are fine.
+
+If a `want` line is missing: iterate on the configure flags or install list and rebuild. Common failure modes:
+
+| Missing from `got` | Likely cause | Fix |
+|---|---|---|
+| `ffi` | `libffi-dev` not installed | add to apt list; `./configure` will detect it |
+| `gettext` | `libgettextpo-dev` missing or wrong package | try `gettext` or `libc6-dev`; on Ubuntu 24.04, stdlib gettext is part of libc |
+| `pcntl` | Flag misspelled or PHP version too old | check `./configure --help | grep pcntl` |
+| `posix` | PHP already compiles it by default but Makefile elided | harmless to add flag explicitly |
+| any | Build error above the `make install` line | scroll back; usually missing dev header |
+
+Once `/tmp/got.txt` is a superset of `/tmp/want.txt`, the build is aligned.
+
+## Rebuild of PECL extension bundles
+
+The audit did not identify an ABI-affecting change in our 8.4 core between the current compiled set and the target compiled set — adding compile-time extensions (`--enable-pcntl`, `--with-ffi`, etc.) does not change the core PHP ABI that separately-loadable `.so` files rely on. Therefore the four PECL bundles (redis, xdebug, pcov, apcu) in `bundles.lock` do **not** need to be rebuilt.
+
+If in practice a PECL extension fails to load against the new bundle (e.g. `symbol not found` at runtime), rebuild the affected extension via `make bundle-ext EXT_NAME=<name> EXT_VERSION=<ver> PHP_ABI=8.4:linux:x86_64:nts` and update `bundles.lock`.
+
+## Documentation updates
+
+Once the build is aligned:
+
+1. Update `docs/compat-matrix.md` §5 to list the **deliberate deviations** — extensions our compiled set includes that v2 does not:
+
+   - mbstring, curl, intl, zip, soap, pdo_mysql, sqlite3, pdo_sqlite, gd (+ freetype/jpeg/webp), pdo_pgsql, pgsql, bcmath.
+   
+   Note that v2 provides these via `apt install phpX.Y-<name>` when listed in the `extensions:` input; our implementation makes them available unconditionally, so `extensions: none` will still have them loaded. This is a documented compat gap. Track in follow-up issue: "honor `extensions: none` beyond the catalog by disabling compile-time extras" (out of scope for this slice).
+
+2. Update `bundles.lock` via the existing CI pipeline (merge the builder change to `main`; `build-php-core.yml` rebuilds and `update-lockfile` PR lands the new digest).
+
+## Commit
+
+```
+git add builders/linux/build-php.sh catalog/php.yaml docs/compat-matrix.md
+git commit -m "fix(builders/linux): add ffi, gettext, pcntl, posix, shmop, sysv* for v2 bundled parity"
+```
+
+Conventional commit. No AI attribution.
+
+## Scope boundary
+
+**In scope**: adding the 8 missing flags + 2 dev headers; re-diffing `php -m` against `compat.BundledExtensions("8.4")`; documenting deviations.
+
+**Out of scope**:
+- Removing any existing flag (banned — subtractive).
+- Per-version variations (8.1, 8.2, 8.3, 8.5 builds are follow-up slices; their `configure_flags` in `catalog/php.yaml` remain unset until then).
+- aarch64 (follow-up).
+- ZTS variant (follow-up).
+- Fixing the "extensions: none doesn't disable compile-time extras" gap (follow-up issue).
+
+## If you want me to drive T12 once Docker is available
+
+Tell me "resume T12", confirm Docker is running, and I'll dispatch a subagent that follows this recipe end-to-end with a 30-minute wall budget. The subagent will iterate until `php -m` matches, commit the changes, and update docs. If the iteration blows the budget, it will pause and hand back with current state so you can debug the specific library/flag that's resisting.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -57,6 +57,8 @@ func (s *PHPSpec) BuildTargets() []BuildTarget {
 			out = append(out, BuildTarget{Version: v, Spec: vs})
 		}
 	}
+	// TODO(8.10): lexicographic string compare — "8.10" < "8.2" is true. Revisit
+	// when PHP 8.10 arrives (estimated post-2028) and switch to semver-aware sort.
 	sort.Slice(out, func(i, j int) bool { return out[i].Version < out[j].Version })
 	return out
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -18,14 +19,46 @@ const (
 	ExtensionKindGit     ExtensionKind = "git"
 )
 
+// PHPSpec describes the PHP catalog entry. It holds per-version metadata
+// under Versions; only versions with Sources set are built by the pipeline,
+// the rest encode compat intent (e.g. bundled extension lists) used for
+// cross-validation against internal/compat.
 type PHPSpec struct {
-	Name              string         `yaml:"name"`
-	Versions          []string       `yaml:"versions"`
-	Source            PHPSource      `yaml:"source"`
-	ABIMatrix         ABIMatrix      `yaml:"abi_matrix"`
-	ConfigureFlags    ConfigureFlags `yaml:"configure_flags"`
+	Name     string                     `yaml:"name"`
+	Versions map[string]*PHPVersionSpec `yaml:"versions"`
+	Smoke    []string                   `yaml:"smoke,omitempty"`
+}
+
+// PHPVersionSpec is the per-version subtree of PHPSpec. Sources, ABIMatrix,
+// and ConfigureFlags are only required for versions that should actually be
+// built by the pipeline; compat-only versions may omit them.
+type PHPVersionSpec struct {
 	BundledExtensions []string       `yaml:"bundled_extensions"`
-	Smoke             []string       `yaml:"smoke"`
+	Sources           *PHPSource     `yaml:"sources,omitempty"`
+	ABIMatrix         ABIMatrix      `yaml:"abi_matrix,omitempty"`
+	ConfigureFlags    ConfigureFlags `yaml:"configure_flags,omitempty"`
+	Smoke             []string       `yaml:"smoke,omitempty"`
+}
+
+// BuildTarget pairs a PHP version with its version-specific spec. Only
+// versions with Sources set produce BuildTargets.
+type BuildTarget struct {
+	Version string
+	Spec    *PHPVersionSpec
+}
+
+// BuildTargets returns the subset of Versions that have Sources set, sorted
+// by version string for deterministic ordering. Callers iterating the build
+// matrix should use this rather than Versions directly.
+func (s *PHPSpec) BuildTargets() []BuildTarget {
+	var out []BuildTarget
+	for v, vs := range s.Versions {
+		if vs != nil && vs.Sources != nil {
+			out = append(out, BuildTarget{Version: v, Spec: vs})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Version < out[j].Version })
+	return out
 }
 
 type PHPSource struct {
@@ -126,8 +159,20 @@ func LoadCatalog(dir string) (*Catalog, error) {
 	return &Catalog{PHP: php, Extensions: extensions}, nil
 }
 
-func (c *Catalog) IsBundled(extName string) bool {
-	return slices.Contains(c.PHP.BundledExtensions, extName)
+// IsBundled reports whether extName is bundled with the given PHP version in
+// this catalog. Returns false if the version is unknown or the catalog has no
+// entry for it. Matching is exact against the per-version
+// bundled_extensions list — callers should pass the normalized (lowercase)
+// identifier.
+func (c *Catalog) IsBundled(phpVersion, extName string) bool {
+	if c.PHP == nil {
+		return false
+	}
+	vs, ok := c.PHP.Versions[phpVersion]
+	if !ok || vs == nil {
+		return false
+	}
+	return slices.Contains(vs.BundledExtensions, extName)
 }
 
 func (c *Catalog) RequiresSeparateBundle(extName string) bool {
@@ -145,11 +190,26 @@ func (s *PHPSpec) Validate() error {
 	if len(s.Versions) == 0 {
 		return fmt.Errorf("PHP spec: at least one version is required")
 	}
-	if s.Source.URL == "" {
-		return fmt.Errorf("PHP spec: source.url is required")
+	hasBuild := false
+	for v, vs := range s.Versions {
+		if vs == nil {
+			return fmt.Errorf("PHP spec %s: version entry is nil", v)
+		}
+		if len(vs.BundledExtensions) == 0 {
+			return fmt.Errorf("PHP spec %s: bundled_extensions is required", v)
+		}
+		if vs.Sources != nil {
+			hasBuild = true
+			if vs.Sources.URL == "" {
+				return fmt.Errorf("PHP spec %s: sources.url is required when sources is set", v)
+			}
+			if len(vs.ABIMatrix.OS) == 0 || len(vs.ABIMatrix.Arch) == 0 || len(vs.ABIMatrix.TS) == 0 {
+				return fmt.Errorf("PHP spec %s: abi_matrix must have at least one value in each dimension", v)
+			}
+		}
 	}
-	if len(s.ABIMatrix.OS) == 0 || len(s.ABIMatrix.Arch) == 0 || len(s.ABIMatrix.TS) == 0 {
-		return fmt.Errorf("PHP spec: abi_matrix must have at least one value in each dimension")
+	if !hasBuild {
+		return fmt.Errorf("PHP spec: at least one version must have sources set for the builder to run")
 	}
 	return nil
 }

--- a/internal/catalog/catalog_compat_test.go
+++ b/internal/catalog/catalog_compat_test.go
@@ -1,0 +1,44 @@
+package catalog
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/buildrush/setup-php/internal/compat"
+)
+
+// TestCatalogBundledMatchesCompat guards against drift between
+// catalog/php.yaml and internal/compat.BundledExtensions. Both encode the
+// same per-version "what does `php -m` report for a default Ondrej PPA
+// build?" truth; if they disagree, one of the two is out of date and must be
+// updated. See docs/compat-matrix.md for provenance.
+func TestCatalogBundledMatchesCompat(t *testing.T) {
+	spec, err := LoadPHPSpec("../../catalog/php.yaml")
+	if err != nil {
+		t.Fatalf("LoadPHPSpec: %v", err)
+	}
+	for v, vs := range spec.Versions {
+		if vs == nil {
+			t.Errorf("php.yaml version %s: spec is nil", v)
+			continue
+		}
+		want := append([]string(nil), compat.BundledExtensions(v)...)
+		got := append([]string(nil), vs.BundledExtensions...)
+		if len(want) == 0 {
+			t.Errorf("compat has no bundled extensions for version %s (unknown to internal/compat?)", v)
+			continue
+		}
+		sort.Strings(want)
+		sort.Strings(got)
+		if len(want) != len(got) {
+			t.Errorf("php.yaml %s bundled_extensions len=%d, compat len=%d\n got=%v\nwant=%v",
+				v, len(got), len(want), got, want)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("php.yaml %s bundled_extensions[%d]=%q, compat=%q", v, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -3,35 +3,36 @@ package catalog
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestLoadPHPSpec(t *testing.T) {
+func TestLoadPHPSpecVersionedLayout(t *testing.T) {
 	yaml := `
 name: php
 versions:
-  - "8.4"
-source:
-  url: "https://www.php.net/distributions/php-{version}.tar.xz"
-  sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
-abi_matrix:
-  os: ["linux"]
-  arch: ["x86_64"]
-  ts: ["nts"]
-configure_flags:
-  common: "--enable-mbstring --with-curl"
-  linux: "--with-pdo-pgsql"
-bundled_extensions:
-  - mbstring
-  - curl
-  - intl
-  - zip
+  "8.1":
+    bundled_extensions: [mbstring, curl]
+  "8.4":
+    bundled_extensions: [mbstring, curl, intl, zip]
+    sources:
+      url: "https://www.php.net/distributions/php-{version}.tar.xz"
+      sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
+    abi_matrix:
+      os: ["linux"]
+      arch: ["x86_64"]
+      ts: ["nts"]
+    configure_flags:
+      common: "--enable-mbstring --with-curl"
+      linux: "--with-pdo-pgsql"
 smoke:
   - 'php -v'
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "php.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644)
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write tmp yaml: %v", err)
+	}
 
 	spec, err := LoadPHPSpec(path)
 	if err != nil {
@@ -40,11 +41,62 @@ smoke:
 	if spec.Name != "php" {
 		t.Errorf("Name = %q, want %q", spec.Name, "php")
 	}
-	if len(spec.Versions) != 1 || spec.Versions[0] != "8.4" {
-		t.Errorf("Versions = %v, want [8.4]", spec.Versions)
+	if len(spec.Versions) != 2 {
+		t.Fatalf("Versions len = %d, want 2", len(spec.Versions))
 	}
-	if len(spec.BundledExtensions) != 4 {
-		t.Errorf("BundledExtensions len = %d, want 4", len(spec.BundledExtensions))
+	v81, ok := spec.Versions["8.1"]
+	if !ok || v81 == nil {
+		t.Fatalf("Versions[8.1] missing")
+	}
+	if v81.Sources != nil {
+		t.Errorf("Versions[8.1].Sources should be nil (compat-only); got %+v", v81.Sources)
+	}
+	if len(v81.BundledExtensions) != 2 {
+		t.Errorf("Versions[8.1].BundledExtensions len = %d, want 2", len(v81.BundledExtensions))
+	}
+	v84, ok := spec.Versions["8.4"]
+	if !ok || v84 == nil {
+		t.Fatalf("Versions[8.4] missing")
+	}
+	if v84.Sources == nil {
+		t.Fatal("Versions[8.4].Sources should be non-nil")
+	}
+	if v84.Sources.URL == "" {
+		t.Error("Versions[8.4].Sources.URL should be set")
+	}
+	if len(v84.BundledExtensions) != 4 {
+		t.Errorf("Versions[8.4].BundledExtensions len = %d, want 4", len(v84.BundledExtensions))
+	}
+	if len(v84.ABIMatrix.OS) != 1 || v84.ABIMatrix.OS[0] != "linux" {
+		t.Errorf("Versions[8.4].ABIMatrix.OS = %v, want [linux]", v84.ABIMatrix.OS)
+	}
+	if v84.ConfigureFlags.Linux == "" {
+		t.Error("Versions[8.4].ConfigureFlags.Linux should be set")
+	}
+}
+
+func TestBuildTargets(t *testing.T) {
+	spec := &PHPSpec{
+		Name: "php",
+		Versions: map[string]*PHPVersionSpec{
+			"8.1": {BundledExtensions: []string{"mbstring"}},
+			"8.3": {BundledExtensions: []string{"mbstring"}},
+			"8.4": {
+				BundledExtensions: []string{"mbstring"},
+				Sources:           &PHPSource{URL: "u"},
+			},
+			"8.5": {
+				BundledExtensions: []string{"mbstring"},
+				Sources:           &PHPSource{URL: "u"},
+			},
+		},
+	}
+	targets := spec.BuildTargets()
+	if len(targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(targets))
+	}
+	if targets[0].Version != "8.4" || targets[1].Version != "8.5" {
+		t.Errorf("targets = %v, want [8.4, 8.5] sorted", []string{targets[0].Version, targets[1].Version})
 	}
 }
 
@@ -106,16 +158,21 @@ note: "Built into PHP core via --enable-mbstring."
 func TestCatalogIsBundled(t *testing.T) {
 	cat := &Catalog{
 		PHP: &PHPSpec{
-			BundledExtensions: []string{"mbstring", "curl", "intl", "zip"},
+			Versions: map[string]*PHPVersionSpec{
+				"8.4": {BundledExtensions: []string{"mbstring", "curl", "intl", "zip"}},
+			},
 		},
 		Extensions: map[string]*ExtensionSpec{},
 	}
 
-	if !cat.IsBundled("mbstring") {
-		t.Error("IsBundled(mbstring) should be true")
+	if !cat.IsBundled("8.4", "mbstring") {
+		t.Error("IsBundled(8.4, mbstring) should be true")
 	}
-	if cat.IsBundled("redis") {
-		t.Error("IsBundled(redis) should be false")
+	if cat.IsBundled("8.4", "redis") {
+		t.Error("IsBundled(8.4, redis) should be false")
+	}
+	if cat.IsBundled("9.9", "mbstring") {
+		t.Error("IsBundled(unknown version) should be false")
 	}
 }
 
@@ -125,20 +182,23 @@ func TestLoadCatalog(t *testing.T) {
 
 	phpYAML := `
 name: php
-versions: ["8.4"]
-source:
-  url: "https://php.net/php-{version}.tar.xz"
-  sig: "https://php.net/php-{version}.tar.xz.asc"
-abi_matrix:
-  os: ["linux"]
-  arch: ["x86_64"]
-  ts: ["nts"]
-configure_flags:
-  common: "--enable-mbstring"
-bundled_extensions: ["mbstring"]
+versions:
+  "8.4":
+    bundled_extensions: ["mbstring"]
+    sources:
+      url: "https://php.net/php-{version}.tar.xz"
+      sig: "https://php.net/php-{version}.tar.xz.asc"
+    abi_matrix:
+      os: ["linux"]
+      arch: ["x86_64"]
+      ts: ["nts"]
+    configure_flags:
+      common: "--enable-mbstring"
 smoke: ["php -v"]
 `
-	os.WriteFile(filepath.Join(dir, "php.yaml"), []byte(phpYAML), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "php.yaml"), []byte(phpYAML), 0o600); err != nil {
+		t.Fatalf("write php.yaml: %v", err)
+	}
 
 	redisYAML := `
 name: redis
@@ -175,9 +235,176 @@ func TestValidatePHPSpecMissingVersions(t *testing.T) {
 	}
 }
 
+func TestValidatePHPSpec(t *testing.T) {
+	buildable := func() *PHPVersionSpec {
+		return &PHPVersionSpec{
+			BundledExtensions: []string{"mbstring"},
+			Sources:           &PHPSource{URL: "u"},
+			ABIMatrix: ABIMatrix{
+				OS:   []string{"linux"},
+				Arch: []string{"x86_64"},
+				TS:   []string{"nts"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		spec    *PHPSpec
+		wantErr string // substring to match
+	}{
+		{
+			name:    "missing name",
+			spec:    &PHPSpec{Versions: map[string]*PHPVersionSpec{"8.4": buildable()}},
+			wantErr: "name is required",
+		},
+		{
+			name: "nil version entry",
+			spec: &PHPSpec{
+				Name:     "php",
+				Versions: map[string]*PHPVersionSpec{"8.4": nil},
+			},
+			wantErr: "version entry is nil",
+		},
+		{
+			name: "missing bundled_extensions",
+			spec: &PHPSpec{
+				Name: "php",
+				Versions: map[string]*PHPVersionSpec{
+					"8.4": {Sources: &PHPSource{URL: "u"}},
+				},
+			},
+			wantErr: "bundled_extensions is required",
+		},
+		{
+			name: "sources without URL",
+			spec: &PHPSpec{
+				Name: "php",
+				Versions: map[string]*PHPVersionSpec{
+					"8.4": {
+						BundledExtensions: []string{"mbstring"},
+						Sources:           &PHPSource{},
+						ABIMatrix: ABIMatrix{
+							OS:   []string{"linux"},
+							Arch: []string{"x86_64"},
+							TS:   []string{"nts"},
+						},
+					},
+				},
+			},
+			wantErr: "sources.url is required",
+		},
+		{
+			name: "sources with empty abi_matrix dimension",
+			spec: &PHPSpec{
+				Name: "php",
+				Versions: map[string]*PHPVersionSpec{
+					"8.4": {
+						BundledExtensions: []string{"mbstring"},
+						Sources:           &PHPSource{URL: "u"},
+						ABIMatrix: ABIMatrix{
+							OS:   []string{"linux"},
+							Arch: []string{},
+							TS:   []string{"nts"},
+						},
+					},
+				},
+			},
+			wantErr: "abi_matrix must have at least one value",
+		},
+		{
+			name: "no version has sources",
+			spec: &PHPSpec{
+				Name: "php",
+				Versions: map[string]*PHPVersionSpec{
+					"8.1": {BundledExtensions: []string{"mbstring"}},
+				},
+			},
+			wantErr: "at least one version must have sources set",
+		},
+		{
+			name: "valid: mix of compat-only and buildable",
+			spec: &PHPSpec{
+				Name: "php",
+				Versions: map[string]*PHPVersionSpec{
+					"8.1": {BundledExtensions: []string{"mbstring"}},
+					"8.4": buildable(),
+				},
+			},
+			wantErr: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateExtSpecMissingSource(t *testing.T) {
 	spec := &ExtensionSpec{Name: "foo", Kind: ExtensionKindPECL}
 	if err := spec.Validate(); err == nil {
 		t.Error("Validate() should fail when PECL source is missing")
+	}
+}
+
+func TestValidateExtSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *ExtensionSpec
+		wantErr bool
+	}{
+		{"missing name", &ExtensionSpec{Kind: ExtensionKindBundled}, true},
+		{"missing kind", &ExtensionSpec{Name: "foo"}, true},
+		{"pecl missing versions", &ExtensionSpec{
+			Name: "foo", Kind: ExtensionKindPECL,
+			Source: ExtensionSource{PECLPackage: "foo"},
+		}, true},
+		{"pecl valid", &ExtensionSpec{
+			Name: "foo", Kind: ExtensionKindPECL,
+			Source:   ExtensionSource{PECLPackage: "foo"},
+			Versions: []string{"1.0.0"},
+		}, false},
+		{"bundled valid without source", &ExtensionSpec{
+			Name: "mbstring", Kind: ExtensionKindBundled,
+		}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiresSeparateBundle(t *testing.T) {
+	cat := &Catalog{
+		Extensions: map[string]*ExtensionSpec{
+			"redis":    {Name: "redis", Kind: ExtensionKindPECL},
+			"mbstring": {Name: "mbstring", Kind: ExtensionKindBundled},
+		},
+	}
+	if !cat.RequiresSeparateBundle("redis") {
+		t.Error("redis (pecl) should require separate bundle")
+	}
+	if cat.RequiresSeparateBundle("mbstring") {
+		t.Error("mbstring (bundled) should not require separate bundle")
+	}
+	if cat.RequiresSeparateBundle("unknown") {
+		t.Error("unknown extension should not require separate bundle")
 	}
 }

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -21,3 +21,22 @@ func UnimplementedInputWarning(inputName, value string) string {
 		inputName, value,
 	)
 }
+
+// DefaultIniValues returns the ini key/value pairs that shivammathur/setup-php@v2
+// sets on Linux runners by default, before any user-supplied ini-values. The
+// caller merges the user values over the top so users can still override.
+//
+// Only unconditional defaults are returned here. Version-conditional or
+// extension-tied defaults (e.g. xdebug.mode=coverage, opcache.*) are applied
+// at compose time by their respective handlers, not by this function.
+//
+// Data source: docs/compat-matrix.md §2.1; mirrored in testdata/default_ini_values.golden.
+func DefaultIniValues(phpVersion string) map[string]string {
+	// Version-independent today. If a version shift emerges, dispatch on
+	// phpVersion (e.g. switch major/minor).
+	_ = phpVersion
+	return map[string]string{
+		"date.timezone": "UTC",
+		"memory_limit":  "-1",
+	}
+}

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -4,7 +4,27 @@
 // deliberate PRs that bump the pinned reference.
 package compat
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+// normalizeExtensionName converts a raw `php -m` extension name to the
+// user-facing identifier used in `extensions:` input and throughout the rest
+// of the codebase (lowercase, with the one historical alias fixup).
+//
+// Rules:
+//   - Lowercase the input.
+//   - "Zend OPcache" (lowercased to "zend opcache") → "opcache", matching the
+//     identifier users type and shivammathur/setup-php@v2's convention.
+//   - All other inputs: just lowercase.
+func normalizeExtensionName(raw string) string {
+	lower := strings.ToLower(raw)
+	if lower == "zend opcache" {
+		return "opcache"
+	}
+	return lower
+}
 
 // UnimplementedInputWarning returns the canonical one-line warning emitted when
 // a user sets an input that buildrush cannot implement given its architecture.
@@ -47,6 +67,11 @@ func DefaultIniValues(phpVersion string) map[string]string {
 // input, based on the Ondrej PPA build for that version. Returns nil for
 // unknown versions.
 //
+// Names are returned as user-facing extension identifiers (lowercase,
+// `Zend OPcache` → `opcache`), suitable for matching against `extensions:`
+// input. The underlying golden files preserve the raw `php -m` casing for
+// audit purposes; normalization happens here.
+//
 // The returned slice is a copy; callers may mutate it without affecting other
 // callers.
 //
@@ -67,7 +92,11 @@ func BundledExtensions(phpVersion string) []string {
 	default:
 		return nil
 	}
-	return append([]string(nil), src...)
+	out := make([]string, len(src))
+	for i, name := range src {
+		out[i] = normalizeExtensionName(name)
+	}
+	return out
 }
 
 // Per-version bundled extension lists. Order matches the native `php -m`

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -26,6 +26,22 @@ func normalizeExtensionName(raw string) string {
 	return lower
 }
 
+// minorOf returns the X.Y prefix of a PHP version string. "8.4.6" → "8.4",
+// "8.4" → "8.4", anything without a second dot is returned unchanged.
+// Used to normalize user-supplied PHP versions before looking up per-minor
+// compat data (which is keyed by X.Y only).
+func minorOf(phpVersion string) string {
+	first := strings.IndexByte(phpVersion, '.')
+	if first < 0 {
+		return phpVersion
+	}
+	second := strings.IndexByte(phpVersion[first+1:], '.')
+	if second < 0 {
+		return phpVersion
+	}
+	return phpVersion[:first+1+second]
+}
+
 // UnimplementedInputWarning returns the canonical one-line warning emitted when
 // a user sets an input that buildrush cannot implement given its architecture.
 // The text starts with GitHub Actions' "::warning::" prefix so runners fold it.
@@ -78,7 +94,7 @@ func DefaultIniValues(phpVersion string) map[string]string {
 // Data source: docs/compat-matrix.md §3; mirrored in testdata/bundled_extensions_<ver>.golden.
 func BundledExtensions(phpVersion string) []string {
 	var src []string
-	switch phpVersion {
+	switch minorOf(phpVersion) {
 	case "8.1":
 		src = bundled81
 	case "8.2":

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -40,3 +40,227 @@ func DefaultIniValues(phpVersion string) map[string]string {
 		"memory_limit":  "-1",
 	}
 }
+
+// BundledExtensions returns the set of extensions compiled in to (or bundled
+// with) the shivammathur/setup-php@v2 Linux build for a given PHP version —
+// i.e. what `php -m` reports after setup-php runs with an empty `extensions:`
+// input, based on the Ondrej PPA build for that version. Returns nil for
+// unknown versions.
+//
+// The returned slice is a copy; callers may mutate it without affecting other
+// callers.
+//
+// Data source: docs/compat-matrix.md §3; mirrored in testdata/bundled_extensions_<ver>.golden.
+func BundledExtensions(phpVersion string) []string {
+	var src []string
+	switch phpVersion {
+	case "8.1":
+		src = bundled81
+	case "8.2":
+		src = bundled82
+	case "8.3":
+		src = bundled83
+	case "8.4":
+		src = bundled84
+	case "8.5":
+		src = bundled85
+	default:
+		return nil
+	}
+	return append([]string(nil), src...)
+}
+
+// Per-version bundled extension lists. Order matches the native `php -m`
+// output captured in the audit (see docs/compat-matrix.md §3.x and the
+// matching testdata/bundled_extensions_<ver>.golden file).
+
+var bundled81 = []string{
+	"calendar",
+	"Core",
+	"ctype",
+	"date",
+	"exif",
+	"FFI",
+	"fileinfo",
+	"filter",
+	"ftp",
+	"gettext",
+	"hash",
+	"iconv",
+	"json",
+	"libxml",
+	"openssl",
+	"pcntl",
+	"pcre",
+	"PDO",
+	"Phar",
+	"posix",
+	"readline",
+	"Reflection",
+	"session",
+	"shmop",
+	"sockets",
+	"sodium",
+	"SPL",
+	"standard",
+	"sysvmsg",
+	"sysvsem",
+	"sysvshm",
+	"tokenizer",
+	"Zend OPcache",
+	"zlib",
+}
+
+var bundled82 = []string{
+	"calendar",
+	"Core",
+	"ctype",
+	"date",
+	"exif",
+	"FFI",
+	"fileinfo",
+	"filter",
+	"ftp",
+	"gettext",
+	"hash",
+	"iconv",
+	"json",
+	"libxml",
+	"openssl",
+	"pcntl",
+	"pcre",
+	"PDO",
+	"Phar",
+	"posix",
+	"random",
+	"readline",
+	"Reflection",
+	"session",
+	"shmop",
+	"sockets",
+	"sodium",
+	"SPL",
+	"standard",
+	"sysvmsg",
+	"sysvsem",
+	"sysvshm",
+	"tokenizer",
+	"Zend OPcache",
+	"zlib",
+}
+
+var bundled83 = []string{
+	"calendar",
+	"Core",
+	"ctype",
+	"date",
+	"exif",
+	"FFI",
+	"fileinfo",
+	"filter",
+	"ftp",
+	"gettext",
+	"hash",
+	"iconv",
+	"json",
+	"libxml",
+	"openssl",
+	"pcntl",
+	"pcre",
+	"PDO",
+	"Phar",
+	"posix",
+	"random",
+	"readline",
+	"Reflection",
+	"session",
+	"shmop",
+	"sockets",
+	"sodium",
+	"SPL",
+	"standard",
+	"sysvmsg",
+	"sysvsem",
+	"sysvshm",
+	"tokenizer",
+	"Zend OPcache",
+	"zlib",
+}
+
+var bundled84 = []string{
+	"calendar",
+	"Core",
+	"ctype",
+	"date",
+	"exif",
+	"FFI",
+	"fileinfo",
+	"filter",
+	"ftp",
+	"gettext",
+	"hash",
+	"iconv",
+	"json",
+	"libxml",
+	"openssl",
+	"pcntl",
+	"pcre",
+	"PDO",
+	"Phar",
+	"posix",
+	"random",
+	"readline",
+	"Reflection",
+	"session",
+	"shmop",
+	"sockets",
+	"sodium",
+	"SPL",
+	"standard",
+	"sysvmsg",
+	"sysvsem",
+	"sysvshm",
+	"tokenizer",
+	"Zend OPcache",
+	"zlib",
+}
+
+var bundled85 = []string{
+	"calendar",
+	"Core",
+	"ctype",
+	"date",
+	"exif",
+	"FFI",
+	"fileinfo",
+	"filter",
+	"ftp",
+	"gettext",
+	"hash",
+	"iconv",
+	"json",
+	"lexbor",
+	"libxml",
+	"openssl",
+	"pcntl",
+	"pcre",
+	"PDO",
+	"Phar",
+	"posix",
+	"random",
+	"readline",
+	"Reflection",
+	"session",
+	"shmop",
+	"sockets",
+	"sodium",
+	"SPL",
+	"standard",
+	"sysvmsg",
+	"sysvsem",
+	"sysvshm",
+	"tokenizer",
+	"uri",
+	"Zend OPcache",
+	"zlib",
+}

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -115,6 +115,30 @@ func BundledExtensions(phpVersion string) []string {
 	return out
 }
 
+// OurBuildBundledExtras returns extensions our own PHP core bundle compiles
+// in beyond v2's baseline (BundledExtensions). Reflects the current builder's
+// ./configure flag set. Merge with BundledExtensions when the runtime needs
+// the full "preloaded by this bundle" list.
+//
+// See docs/superpowers/specs/2026-04-17-phase2-t12-handoff.md for the planned
+// builder alignment; this list is intentionally a superset of v2's baseline
+// until that work lands.
+func OurBuildBundledExtras(phpVersion string) []string {
+	switch minorOf(phpVersion) {
+	case "8.4":
+		// Matches the --enable-*/--with-* flags in builders/linux/build-php.sh
+		// minus anything already in v2's baseline.
+		return []string{
+			"mbstring", "curl", "intl", "zip",
+			"pdo_mysql", "pdo_sqlite", "sqlite3", "pdo_pgsql", "pgsql",
+			"bcmath", "soap", "gd",
+			"xml", "dom", "simplexml", "xmlreader", "xmlwriter",
+		}
+	default:
+		return nil
+	}
+}
+
 // Per-version bundled extension lists. Order matches the native `php -m`
 // output captured in the audit (see docs/compat-matrix.md §3.x and the
 // matching testdata/bundled_extensions_<ver>.golden file).

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -1,0 +1,23 @@
+// Package compat is the single source of truth for drop-in compatibility with
+// shivammathur/setup-php@v2. All data in this package is derived from the
+// audit documented in docs/compat-matrix.md and should be updated via
+// deliberate PRs that bump the pinned reference.
+package compat
+
+import "fmt"
+
+// UnimplementedInputWarning returns the canonical one-line warning emitted when
+// a user sets an input that buildrush cannot implement given its architecture.
+// The text starts with GitHub Actions' "::warning::" prefix so runners fold it.
+func UnimplementedInputWarning(inputName, value string) string {
+	if inputName == "update" {
+		return fmt.Sprintf(
+			"::warning::input 'update=%s' is not supported by buildrush/setup-php (prebuilt bundles are already up to date); ignoring",
+			value,
+		)
+	}
+	return fmt.Sprintf(
+		"::warning::input '%s=%s' is not supported by buildrush/setup-php; ignoring",
+		inputName, value,
+	)
+}

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -61,7 +61,6 @@ func TestDefaultIniValuesMatchesGolden(t *testing.T) {
 func TestBundledExtensionsMatchGolden(t *testing.T) {
 	versions := []string{"8.1", "8.2", "8.3", "8.4", "8.5"}
 	for _, v := range versions {
-		v := v
 		t.Run(v, func(t *testing.T) {
 			got := BundledExtensions(v)
 			want := readGoldenLines(t, fmt.Sprintf("bundled_extensions_%s.golden", v))
@@ -98,7 +97,7 @@ func readGoldenLines(t *testing.T, name string) []string {
 		t.Fatalf("read golden %s: %v", path, err)
 	}
 	var out []string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -63,7 +63,15 @@ func TestBundledExtensionsMatchGolden(t *testing.T) {
 	for _, v := range versions {
 		t.Run(v, func(t *testing.T) {
 			got := BundledExtensions(v)
-			want := readGoldenLines(t, fmt.Sprintf("bundled_extensions_%s.golden", v))
+			raw := readGoldenLines(t, fmt.Sprintf("bundled_extensions_%s.golden", v))
+			// Golden files preserve raw `php -m` casing for audit; apply the
+			// same normalization BundledExtensions does before comparing, so
+			// the test asserts the normalization is stable without coupling
+			// the golden to the user-facing identifier form.
+			want := make([]string, len(raw))
+			for i, line := range raw {
+				want[i] = normalizeExtensionName(line)
+			}
 			gotSorted := append([]string(nil), got...)
 			wantSorted := append([]string(nil), want...)
 			sort.Strings(gotSorted)
@@ -76,6 +84,27 @@ func TestBundledExtensionsMatchGolden(t *testing.T) {
 				if gotSorted[i] != wantSorted[i] {
 					t.Errorf("BundledExtensions(%q)[%d] = %q, want %q", v, i, gotSorted[i], wantSorted[i])
 				}
+			}
+		})
+	}
+}
+
+func TestNormalizeExtensionName(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"zend opcache native", "Zend OPcache", "opcache"},
+		{"zend opcache lowercase", "zend opcache", "opcache"},
+		{"PDO", "PDO", "pdo"},
+		{"Core", "Core", "core"},
+		{"mbstring idempotent", "mbstring", "mbstring"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeExtensionName(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeExtensionName(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -1,0 +1,30 @@
+package compat
+
+import "testing"
+
+func TestUnimplementedInputWarning(t *testing.T) {
+	tests := []struct {
+		name, input, value, want string
+	}{
+		{
+			name:  "update true",
+			input: "update",
+			value: "true",
+			want:  "::warning::input 'update=true' is not supported by buildrush/setup-php (prebuilt bundles are already up to date); ignoring",
+		},
+		{
+			name:  "unknown input",
+			input: "foo",
+			value: "bar",
+			want:  "::warning::input 'foo=bar' is not supported by buildrush/setup-php; ignoring",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UnimplementedInputWarning(tt.input, tt.value)
+			if got != tt.want {
+				t.Errorf("UnimplementedInputWarning(%q, %q) = %q, want %q", tt.input, tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -1,8 +1,10 @@
 package compat
 
 import (
-	"bufio"
+	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -37,19 +39,8 @@ func TestUnimplementedInputWarning(t *testing.T) {
 func TestDefaultIniValuesMatchesGolden(t *testing.T) {
 	got := DefaultIniValues("8.4")
 
-	f, err := os.Open("testdata/default_ini_values.golden")
-	if err != nil {
-		t.Fatalf("open golden: %v", err)
-	}
-	defer f.Close()
-
 	want := map[string]string{}
-	s := bufio.NewScanner(f)
-	for s.Scan() {
-		line := strings.TrimSpace(s.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
+	for _, line := range readGoldenLines(t, "default_ini_values.golden") {
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
 			t.Fatalf("bad golden line: %q", line)
@@ -65,4 +56,54 @@ func TestDefaultIniValuesMatchesGolden(t *testing.T) {
 			t.Errorf("DefaultIniValues[%q] = %q, want %q", k, got[k], v)
 		}
 	}
+}
+
+func TestBundledExtensionsMatchGolden(t *testing.T) {
+	versions := []string{"8.1", "8.2", "8.3", "8.4", "8.5"}
+	for _, v := range versions {
+		v := v
+		t.Run(v, func(t *testing.T) {
+			got := BundledExtensions(v)
+			want := readGoldenLines(t, fmt.Sprintf("bundled_extensions_%s.golden", v))
+			gotSorted := append([]string(nil), got...)
+			wantSorted := append([]string(nil), want...)
+			sort.Strings(gotSorted)
+			sort.Strings(wantSorted)
+			if len(gotSorted) != len(wantSorted) {
+				t.Fatalf("BundledExtensions(%q) len=%d, want %d\n got: %v\nwant: %v",
+					v, len(gotSorted), len(wantSorted), gotSorted, wantSorted)
+			}
+			for i := range wantSorted {
+				if gotSorted[i] != wantSorted[i] {
+					t.Errorf("BundledExtensions(%q)[%d] = %q, want %q", v, i, gotSorted[i], wantSorted[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBundledExtensionsUnknownVersion(t *testing.T) {
+	if got := BundledExtensions("7.4"); got != nil {
+		t.Errorf("BundledExtensions(7.4) = %v, want nil", got)
+	}
+}
+
+// readGoldenLines reads testdata/<name>, strips blank lines and # comments,
+// returns the remaining non-empty lines in file order.
+func readGoldenLines(t *testing.T, name string) []string {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", path, err)
+	}
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
 }

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -126,6 +127,25 @@ func TestBundledExtensionsAcceptsFullTriple(t *testing.T) {
 		if minor[i] != triple[i] {
 			t.Errorf("diff at [%d]: minor=%q, triple=%q", i, minor[i], triple[i])
 		}
+	}
+}
+
+func TestOurBuildBundledExtras(t *testing.T) {
+	// 8.4 must include the configure-flag extras so runtime resolution treats
+	// them as preloaded (until T12 aligns our build with v2's slim baseline).
+	got := OurBuildBundledExtras("8.4")
+	for _, want := range []string{"mbstring", "curl", "intl", "zip", "bcmath", "gd"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("OurBuildBundledExtras(8.4) missing %q; got %v", want, got)
+		}
+	}
+	// Unknown/untracked version returns nil.
+	if got := OurBuildBundledExtras("7.4"); got != nil {
+		t.Errorf("OurBuildBundledExtras(7.4) = %v, want nil", got)
+	}
+	// Full-triple input normalizes to minor.
+	if got := OurBuildBundledExtras("8.4.6"); !slices.Contains(got, "curl") {
+		t.Errorf("OurBuildBundledExtras(8.4.6) did not normalize to 8.4; got %v", got)
 	}
 }
 

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -3,7 +3,6 @@ package compat
 import (
 	"bufio"
 	"os"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -65,15 +64,5 @@ func TestDefaultIniValuesMatchesGolden(t *testing.T) {
 		if got[k] != v {
 			t.Errorf("DefaultIniValues[%q] = %q, want %q", k, got[k], v)
 		}
-	}
-
-	// determinism reminder — map iteration is random; ensuring keys sortable
-	keys := make([]string, 0, len(got))
-	for k := range got {
-		keys = append(keys, k)
-	}
-	if !sort.StringsAreSorted(keys) {
-		// allowed — just an observation, not a failure
-		_ = keys
 	}
 }

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -1,6 +1,12 @@
 package compat
 
-import "testing"
+import (
+	"bufio"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
 
 func TestUnimplementedInputWarning(t *testing.T) {
 	tests := []struct {
@@ -26,5 +32,48 @@ func TestUnimplementedInputWarning(t *testing.T) {
 				t.Errorf("UnimplementedInputWarning(%q, %q) = %q, want %q", tt.input, tt.value, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDefaultIniValuesMatchesGolden(t *testing.T) {
+	got := DefaultIniValues("8.4")
+
+	f, err := os.Open("testdata/default_ini_values.golden")
+	if err != nil {
+		t.Fatalf("open golden: %v", err)
+	}
+	defer f.Close()
+
+	want := map[string]string{}
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			t.Fatalf("bad golden line: %q", line)
+		}
+		want[parts[0]] = parts[1]
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("DefaultIniValues len = %d, golden len = %d", len(got), len(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("DefaultIniValues[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+
+	// determinism reminder — map iteration is random; ensuring keys sortable
+	keys := make([]string, 0, len(got))
+	for k := range got {
+		keys = append(keys, k)
+	}
+	if !sort.StringsAreSorted(keys) {
+		// allowed — just an observation, not a failure
+		_ = keys
 	}
 }

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -110,6 +110,42 @@ func TestNormalizeExtensionName(t *testing.T) {
 	}
 }
 
+func TestBundledExtensionsAcceptsFullTriple(t *testing.T) {
+	// User may supply "8.4.6" (from php-version-file or explicit input).
+	// BundledExtensions should normalize to the minor and return the same
+	// data as for "8.4".
+	minor := BundledExtensions("8.4")
+	triple := BundledExtensions("8.4.6")
+	if len(triple) == 0 {
+		t.Fatalf("BundledExtensions(8.4.6) returned nil; expected to normalize to 8.4")
+	}
+	if len(minor) != len(triple) {
+		t.Fatalf("BundledExtensions(8.4) len=%d, BundledExtensions(8.4.6) len=%d", len(minor), len(triple))
+	}
+	for i := range minor {
+		if minor[i] != triple[i] {
+			t.Errorf("diff at [%d]: minor=%q, triple=%q", i, minor[i], triple[i])
+		}
+	}
+}
+
+func TestMinorOf(t *testing.T) {
+	tests := map[string]string{
+		"8.4":       "8.4",
+		"8.4.6":     "8.4",
+		"8.4.20-rc": "8.4",
+		"8.10":      "8.10",
+		"8.10.0":    "8.10",
+		"":          "",
+		"8":         "8",
+	}
+	for in, want := range tests {
+		if got := minorOf(in); got != want {
+			t.Errorf("minorOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestBundledExtensionsUnknownVersion(t *testing.T) {
 	if got := BundledExtensions("7.4"); got != nil {
 		t.Errorf("BundledExtensions(7.4) = %v, want nil", got)

--- a/internal/compat/testdata/bundled_extensions_8.1.golden
+++ b/internal/compat/testdata/bundled_extensions_8.1.golden
@@ -1,0 +1,45 @@
+# Built-in / default-loaded extensions for PHP 8.1 on Ondrej PPA, Ubuntu 24.04 noble.
+# Source: docs/compat-matrix.md §3.1, pinned SHA accd6127cb78bee3e8082180cb391013d204ef9f.
+# Snapshot: Sat, 11 Apr 2026 10:46:03 UTC.
+#
+# Includes: compiled-in extensions + default-loaded extensions from clean
+# `apt install php8.1-cli` (no extras). One name per line, native `php -m` order.
+#
+# NOT included (and why):
+#   - Separately-installed PECL/PPA extensions (redis, xdebug, pcov, apcu, imagick,
+#     memcached, mongodb, etc.) — those come from the catalog + lockfile at runtime.
+
+calendar
+Core
+ctype
+date
+exif
+FFI
+fileinfo
+filter
+ftp
+gettext
+hash
+iconv
+json
+libxml
+openssl
+pcntl
+pcre
+PDO
+Phar
+posix
+readline
+Reflection
+session
+shmop
+sockets
+sodium
+SPL
+standard
+sysvmsg
+sysvsem
+sysvshm
+tokenizer
+Zend OPcache
+zlib

--- a/internal/compat/testdata/bundled_extensions_8.2.golden
+++ b/internal/compat/testdata/bundled_extensions_8.2.golden
@@ -1,0 +1,46 @@
+# Built-in / default-loaded extensions for PHP 8.2 on Ondrej PPA, Ubuntu 24.04 noble.
+# Source: docs/compat-matrix.md §3.2, pinned SHA accd6127cb78bee3e8082180cb391013d204ef9f.
+# Snapshot: Sat, 11 Apr 2026 10:46:03 UTC.
+#
+# Includes: compiled-in extensions + default-loaded extensions from clean
+# `apt install php8.2-cli` (no extras). One name per line, native `php -m` order.
+#
+# NOT included (and why):
+#   - Separately-installed PECL/PPA extensions (redis, xdebug, pcov, apcu, imagick,
+#     memcached, mongodb, etc.) — those come from the catalog + lockfile at runtime.
+
+calendar
+Core
+ctype
+date
+exif
+FFI
+fileinfo
+filter
+ftp
+gettext
+hash
+iconv
+json
+libxml
+openssl
+pcntl
+pcre
+PDO
+Phar
+posix
+random
+readline
+Reflection
+session
+shmop
+sockets
+sodium
+SPL
+standard
+sysvmsg
+sysvsem
+sysvshm
+tokenizer
+Zend OPcache
+zlib

--- a/internal/compat/testdata/bundled_extensions_8.3.golden
+++ b/internal/compat/testdata/bundled_extensions_8.3.golden
@@ -1,0 +1,46 @@
+# Built-in / default-loaded extensions for PHP 8.3 on Ondrej PPA, Ubuntu 24.04 noble.
+# Source: docs/compat-matrix.md §3.3, pinned SHA accd6127cb78bee3e8082180cb391013d204ef9f.
+# Snapshot: Sat, 11 Apr 2026 10:46:03 UTC.
+#
+# Includes: compiled-in extensions + default-loaded extensions from clean
+# `apt install php8.3-cli` (no extras). One name per line, native `php -m` order.
+#
+# NOT included (and why):
+#   - Separately-installed PECL/PPA extensions (redis, xdebug, pcov, apcu, imagick,
+#     memcached, mongodb, etc.) — those come from the catalog + lockfile at runtime.
+
+calendar
+Core
+ctype
+date
+exif
+FFI
+fileinfo
+filter
+ftp
+gettext
+hash
+iconv
+json
+libxml
+openssl
+pcntl
+pcre
+PDO
+Phar
+posix
+random
+readline
+Reflection
+session
+shmop
+sockets
+sodium
+SPL
+standard
+sysvmsg
+sysvsem
+sysvshm
+tokenizer
+Zend OPcache
+zlib

--- a/internal/compat/testdata/bundled_extensions_8.4.golden
+++ b/internal/compat/testdata/bundled_extensions_8.4.golden
@@ -1,0 +1,46 @@
+# Built-in / default-loaded extensions for PHP 8.4 on Ondrej PPA, Ubuntu 24.04 noble.
+# Source: docs/compat-matrix.md §3.4, pinned SHA accd6127cb78bee3e8082180cb391013d204ef9f.
+# Snapshot: Sat, 11 Apr 2026 10:46:03 UTC.
+#
+# Includes: compiled-in extensions + default-loaded extensions from clean
+# `apt install php8.4-cli` (no extras). One name per line, native `php -m` order.
+#
+# NOT included (and why):
+#   - Separately-installed PECL/PPA extensions (redis, xdebug, pcov, apcu, imagick,
+#     memcached, mongodb, etc.) — those come from the catalog + lockfile at runtime.
+
+calendar
+Core
+ctype
+date
+exif
+FFI
+fileinfo
+filter
+ftp
+gettext
+hash
+iconv
+json
+libxml
+openssl
+pcntl
+pcre
+PDO
+Phar
+posix
+random
+readline
+Reflection
+session
+shmop
+sockets
+sodium
+SPL
+standard
+sysvmsg
+sysvsem
+sysvshm
+tokenizer
+Zend OPcache
+zlib

--- a/internal/compat/testdata/bundled_extensions_8.5.golden
+++ b/internal/compat/testdata/bundled_extensions_8.5.golden
@@ -1,0 +1,48 @@
+# Built-in / default-loaded extensions for PHP 8.5 on Ondrej PPA, Ubuntu 24.04 noble.
+# Source: docs/compat-matrix.md §3.5, pinned SHA accd6127cb78bee3e8082180cb391013d204ef9f.
+# Snapshot: Sat, 11 Apr 2026 10:46:03 UTC.
+#
+# Includes: compiled-in extensions + default-loaded extensions from clean
+# `apt install php8.5-cli` (no extras). One name per line, native `php -m` order.
+#
+# NOT included (and why):
+#   - Separately-installed PECL/PPA extensions (redis, xdebug, pcov, apcu, imagick,
+#     memcached, mongodb, etc.) — those come from the catalog + lockfile at runtime.
+
+calendar
+Core
+ctype
+date
+exif
+FFI
+fileinfo
+filter
+ftp
+gettext
+hash
+iconv
+json
+lexbor
+libxml
+openssl
+pcntl
+pcre
+PDO
+Phar
+posix
+random
+readline
+Reflection
+session
+shmop
+sockets
+sodium
+SPL
+standard
+sysvmsg
+sysvsem
+sysvshm
+tokenizer
+uri
+Zend OPcache
+zlib

--- a/internal/compat/testdata/default_ini_values.golden
+++ b/internal/compat/testdata/default_ini_values.golden
@@ -1,0 +1,7 @@
+# Defaults set by shivammathur/setup-php@v2 on Linux runners (unconditional).
+# Source: docs/compat-matrix.md §2.1, pinned SHA accd6127cb78bee3e8082180cb391013d204ef9f.
+# NOTE: version-conditional defaults (xdebug.mode=coverage when coverage:xdebug,
+# opcache.* when opcache loaded) are handled at compose time, not here.
+
+date.timezone=UTC
+memory_limit=-1

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -66,19 +66,6 @@ func WriteIniFragment(confDir, extName string, lines []string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
 
-func WriteIniValues(confDir string, values []plan.IniValue) error {
-	if len(values) == 0 {
-		return nil
-	}
-	var lines []string
-	for _, v := range values {
-		lines = append(lines, fmt.Sprintf("%s=%s", v.Key, v.Value))
-	}
-	path := filepath.Join(confDir, "99-user.ini")
-	content := strings.Join(lines, "\n") + "\n"
-	return os.WriteFile(path, []byte(content), 0o600)
-}
-
 // WriteIniValuesWithDefaults writes compat default ini values first, then user
 // values on top — later writes win because PHP processes the file top-to-bottom.
 // Default keys are written in deterministic (sorted) order. User values are

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -111,13 +111,12 @@ func WriteIniValuesWithDefaults(confDir string, defaults map[string]string, user
 
 // WriteDisableExtension writes a conf.d fragment that documents and enforces
 // non-loading of the named extension. The "00-" filename prefix makes it sort
-// before typical extension-loading fragments (e.g. "20-ext.ini" or "ext.ini"),
-// so any later fragment that tries to `extension=<name>` is overridden by this
-// file's commented-out form.
+// before extension-loading fragments (this codebase writes them as plain
+// "<name>.ini"; see WriteIniFragment).
 //
 // Because our composed PHP only loads what conf.d explicitly declares, the
-// primary mechanism is simply the absence of the load directive; this file
-// provides a durable audit trail and defence-in-depth.
+// primary mechanism for disabling is simply the absence of the load directive;
+// this file provides a durable audit trail and defence-in-depth.
 func WriteDisableExtension(confDir, extName string) error {
 	path := filepath.Join(confDir, fmt.Sprintf("00-disable-%s.ini", extName))
 	content := fmt.Sprintf("; disabled by extensions: :%s\n; extension=%s\n", extName, extName)

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/buildrush/setup-php/internal/plan"
@@ -75,5 +76,50 @@ func WriteIniValues(confDir string, values []plan.IniValue) error {
 	}
 	path := filepath.Join(confDir, "99-user.ini")
 	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+// WriteIniValuesWithDefaults writes compat default ini values first, then user
+// values on top — later writes win because PHP processes the file top-to-bottom.
+// Default keys are written in deterministic (sorted) order. User values are
+// written in their supplied order, matching how shivammathur/setup-php@v2
+// appends user-specified ini-values on top of the base ini.
+//
+// If both maps are empty, no file is written and nil is returned.
+func WriteIniValuesWithDefaults(confDir string, defaults map[string]string, user []plan.IniValue) error {
+	if len(defaults) == 0 && len(user) == 0 {
+		return nil
+	}
+
+	defKeys := make([]string, 0, len(defaults))
+	for k := range defaults {
+		defKeys = append(defKeys, k)
+	}
+	sort.Strings(defKeys)
+
+	var lines []string
+	for _, k := range defKeys {
+		lines = append(lines, fmt.Sprintf("%s=%s", k, defaults[k]))
+	}
+	for _, v := range user {
+		lines = append(lines, fmt.Sprintf("%s=%s", v.Key, v.Value))
+	}
+
+	path := filepath.Join(confDir, "99-user.ini")
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
+}
+
+// WriteDisableExtension writes a conf.d fragment that documents and enforces
+// non-loading of the named extension. The "00-" filename prefix makes it sort
+// before typical extension-loading fragments (e.g. "20-ext.ini" or "ext.ini"),
+// so any later fragment that tries to `extension=<name>` is overridden by this
+// file's commented-out form.
+//
+// Because our composed PHP only loads what conf.d explicitly declares, the
+// primary mechanism is simply the absence of the load directive; this file
+// provides a durable audit trail and defence-in-depth.
+func WriteDisableExtension(confDir, extName string) error {
+	path := filepath.Join(confDir, fmt.Sprintf("00-disable-%s.ini", extName))
+	content := fmt.Sprintf("; disabled by extensions: :%s\n; extension=%s\n", extName, extName)
 	return os.WriteFile(path, []byte(content), 0o600)
 }

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -47,27 +47,6 @@ func TestWriteIniFragment(t *testing.T) {
 	}
 }
 
-func TestWriteIniValues(t *testing.T) {
-	dir := t.TempDir()
-	vals := []plan.IniValue{
-		{Key: "memory_limit", Value: "256M"},
-		{Key: "display_errors", Value: "On"},
-	}
-	err := WriteIniValues(dir, vals)
-	if err != nil {
-		t.Fatalf("WriteIniValues() error = %v", err)
-	}
-
-	data, _ := os.ReadFile(filepath.Join(dir, "99-user.ini"))
-	content := string(data)
-	if !strings.Contains(content, "memory_limit=256M") {
-		t.Errorf("should contain memory_limit=256M, got %q", content)
-	}
-	if !strings.Contains(content, "display_errors=On") {
-		t.Errorf("should contain display_errors=On, got %q", content)
-	}
-}
-
 func TestWriteIniValuesWithDefaults(t *testing.T) {
 	dir := t.TempDir()
 	defaults := map[string]string{

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -68,6 +68,104 @@ func TestWriteIniValues(t *testing.T) {
 	}
 }
 
+func TestWriteIniValuesWithDefaults(t *testing.T) {
+	dir := t.TempDir()
+	defaults := map[string]string{
+		"memory_limit":  "-1",
+		"date.timezone": "UTC",
+	}
+	user := []plan.IniValue{
+		{Key: "memory_limit", Value: "512M"}, // overrides default
+		{Key: "display_errors", Value: "On"},
+	}
+
+	if err := WriteIniValuesWithDefaults(dir, defaults, user); err != nil {
+		t.Fatalf("WriteIniValuesWithDefaults: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "99-user.ini"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(data)
+
+	if !strings.Contains(s, "memory_limit=512M\n") {
+		t.Errorf("user override not present; got:\n%s", s)
+	}
+	// Verify the user override line comes AFTER the default line
+	defaultIdx := strings.Index(s, "memory_limit=-1\n")
+	userIdx := strings.Index(s, "memory_limit=512M\n")
+	if defaultIdx == -1 {
+		t.Errorf("default memory_limit not present; got:\n%s", s)
+	} else if userIdx <= defaultIdx {
+		t.Errorf("user override at idx %d should come after default at idx %d; got:\n%s",
+			userIdx, defaultIdx, s)
+	}
+	if !strings.Contains(s, "date.timezone=UTC\n") {
+		t.Errorf("untouched default missing; got:\n%s", s)
+	}
+	if !strings.Contains(s, "display_errors=On\n") {
+		t.Errorf("user-only value missing; got:\n%s", s)
+	}
+}
+
+func TestWriteIniValuesWithDefaultsSorted(t *testing.T) {
+	dir := t.TempDir()
+	defaults := map[string]string{
+		"z_key": "1",
+		"a_key": "2",
+		"m_key": "3",
+	}
+	if err := WriteIniValuesWithDefaults(dir, defaults, nil); err != nil {
+		t.Fatalf("WriteIniValuesWithDefaults: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "99-user.ini"))
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3: %v", len(lines), lines)
+	}
+	// Defaults must appear in sorted key order.
+	if !strings.HasPrefix(lines[0], "a_key=") ||
+		!strings.HasPrefix(lines[1], "m_key=") ||
+		!strings.HasPrefix(lines[2], "z_key=") {
+		t.Errorf("defaults not sorted; got:\n%v", lines)
+	}
+}
+
+func TestWriteIniValuesWithDefaultsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteIniValuesWithDefaults(dir, nil, nil); err != nil {
+		t.Fatalf("WriteIniValuesWithDefaults: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "99-user.ini")); !os.IsNotExist(err) {
+		t.Errorf("expected no file when both defaults and user are empty, err=%v", err)
+	}
+}
+
+func TestWriteDisableExtension(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteDisableExtension(dir, "opcache"); err != nil {
+		t.Fatalf("WriteDisableExtension: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*.ini"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected 1 ini file, got %v (err=%v)", matches, err)
+	}
+	name := filepath.Base(matches[0])
+	if !strings.HasPrefix(name, "00-") {
+		t.Errorf("disable fragment must have 00- prefix to sort early; got %s", name)
+	}
+	if !strings.Contains(name, "opcache") {
+		t.Errorf("disable fragment filename should mention opcache; got %s", name)
+	}
+
+	data, _ := os.ReadFile(matches[0])
+	if !strings.Contains(string(data), "opcache") {
+		t.Errorf("disable fragment body should mention opcache; got:\n%s", data)
+	}
+}
+
 func TestCompose(t *testing.T) {
 	dir := t.TempDir()
 	extDir := filepath.Join(dir, "ext")

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -11,19 +11,21 @@ import (
 )
 
 type Plan struct {
-	PHPVersion   string
-	Extensions   []string
-	IniValues    []IniValue
-	Coverage     CoverageDriver
-	Tools        []string
-	ThreadSafety string
-	OS           string
-	Arch         string
-	FailFast     bool
-	Update       bool
-	IniFile      string
-	Debug        bool
-	Verbose      bool
+	PHPVersion        string
+	Extensions        []string
+	ExtensionsExclude []string
+	ExtensionsReset   bool
+	IniValues         []IniValue
+	Coverage          CoverageDriver
+	Tools             []string
+	ThreadSafety      string
+	OS                string
+	Arch              string
+	FailFast          bool
+	Update            bool
+	IniFile           string
+	Debug             bool
+	Verbose           bool
 }
 
 type IniValue struct {
@@ -59,7 +61,10 @@ func FromEnv() (*Plan, error) {
 		}
 	}
 
-	p.Extensions = ParseExtensions(os.Getenv("INPUT_EXTENSIONS"))
+	incl, excl, reset := ParseExtensions(os.Getenv("INPUT_EXTENSIONS"))
+	p.Extensions = incl
+	p.ExtensionsExclude = excl
+	p.ExtensionsReset = reset
 
 	if raw := os.Getenv("INPUT_INI-VALUES"); raw != "" {
 		vals, err := ParseIniValues(raw)
@@ -76,24 +81,52 @@ func FromEnv() (*Plan, error) {
 	return p, nil
 }
 
-func ParseExtensions(raw string) []string {
+// ParseExtensions parses shivammathur/setup-php@v2's extensions syntax.
+// Recognized tokens:
+//   - bare name (e.g. "redis") → include
+//   - ":name" → exclude
+//   - "none" → reset both include and exclude to empty; subsequent tokens process normally
+//
+// Output is sorted, deduplicated, and lower-cased.
+func ParseExtensions(raw string) (include, exclude []string, reset bool) {
 	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "none" {
-		return nil
+	if raw == "" {
+		return nil, nil, false
 	}
 
-	seen := make(map[string]bool)
-	var result []string
-	for ext := range strings.SplitSeq(raw, ",") {
-		ext = strings.TrimSpace(strings.ToLower(ext))
-		if ext == "" || seen[ext] {
-			continue
+	seenIncl := map[string]bool{}
+	seenExcl := map[string]bool{}
+
+	for tok := range strings.SplitSeq(raw, ",") {
+		tok = strings.TrimSpace(strings.ToLower(tok))
+		switch {
+		case tok == "":
+			// skip
+		case tok == "none":
+			include = nil
+			exclude = nil
+			seenIncl = map[string]bool{}
+			seenExcl = map[string]bool{}
+			reset = true
+		case strings.HasPrefix(tok, ":"):
+			name := strings.TrimPrefix(tok, ":")
+			if name == "" || seenExcl[name] {
+				continue
+			}
+			seenExcl[name] = true
+			exclude = append(exclude, name)
+		default:
+			if seenIncl[tok] {
+				continue
+			}
+			seenIncl[tok] = true
+			include = append(include, tok)
 		}
-		seen[ext] = true
-		result = append(result, ext)
 	}
-	sort.Strings(result)
-	return result
+
+	sort.Strings(include)
+	sort.Strings(exclude)
+	return include, exclude, reset
 }
 
 func ParseIniValues(raw string) ([]IniValue, error) {
@@ -150,6 +183,8 @@ func (p *Plan) Hash() string {
 	_, _ = fmt.Fprintf(h, "arch:%s\n", p.Arch)
 	_, _ = fmt.Fprintf(h, "ts:%s\n", p.ThreadSafety)
 	_, _ = fmt.Fprintf(h, "exts:%s\n", strings.Join(p.Extensions, ","))
+	_, _ = fmt.Fprintf(h, "excl:%s\n", strings.Join(p.ExtensionsExclude, ","))
+	_, _ = fmt.Fprintf(h, "reset:%t\n", p.ExtensionsReset)
 	_, _ = fmt.Fprintf(h, "coverage:%s\n", p.Coverage)
 	for _, iv := range p.IniValues {
 		_, _ = fmt.Fprintf(h, "ini:%s=%s\n", iv.Key, iv.Value)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -20,6 +20,8 @@ type Plan struct {
 	OS           string
 	Arch         string
 	FailFast     bool
+	Update       bool
+	IniFile      string
 	Debug        bool
 	Verbose      bool
 }
@@ -45,6 +47,8 @@ func FromEnv() (*Plan, error) {
 		OS:           normalizeOS(os.Getenv("RUNNER_OS")),
 		Arch:         normalizeArch(os.Getenv("RUNNER_ARCH")),
 		FailFast:     os.Getenv("INPUT_FAIL-FAST") == "true",
+		Update:       os.Getenv("INPUT_UPDATE") == "true",
+		IniFile:      envOrDefault("INPUT_INI-FILE", "production"),
 		Debug:        os.Getenv("INPUT_DEBUG") == "true",
 		Verbose:      os.Getenv("INPUT_VERBOSE") == "true",
 	}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -87,7 +87,7 @@ func FromEnv() (*Plan, error) {
 //   - ":name" → exclude
 //   - "none" → reset both include and exclude to empty; subsequent tokens process normally
 //
-// Output is sorted, deduplicated, and lower-cased.
+// Both include and exclude are sorted, deduplicated, and lower-cased.
 func ParseExtensions(raw string) (include, exclude []string, reset bool) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -82,14 +83,18 @@ func TestParseExtensions(t *testing.T) {
 		{"none then include", "none, redis, curl", []string{"curl", "redis"}, nil, true},
 		{"none then include and exclude", "none, redis, :opcache", []string{"redis"}, []string{"opcache"}, true},
 		{"none anywhere resets before it", "redis, none, curl", []string{"curl"}, nil, true},
+		{"exclude literal 'none' with :none", ":none", nil, []string{"none"}, false},
+		{"bare colon is dropped", ":", nil, nil, false},
+		{"uppercase NONE is reset", "NONE, redis", []string{"redis"}, nil, true},
+		{"same name in both sets is preserved", "redis, :redis", []string{"redis"}, []string{"redis"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			incl, excl, reset := ParseExtensions(tt.input)
-			if !equalStringSlice(incl, tt.wantInclude) {
+			if !slices.Equal(incl, tt.wantInclude) {
 				t.Errorf("include = %v, want %v", incl, tt.wantInclude)
 			}
-			if !equalStringSlice(excl, tt.wantExclude) {
+			if !slices.Equal(excl, tt.wantExclude) {
 				t.Errorf("exclude = %v, want %v", excl, tt.wantExclude)
 			}
 			if reset != tt.wantReset {
@@ -97,18 +102,6 @@ func TestParseExtensions(t *testing.T) {
 			}
 		})
 	}
-}
-
-func equalStringSlice(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func TestParseIniValues(t *testing.T) {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -25,6 +25,12 @@ func TestFromEnvFull(t *testing.T) {
 	if len(p.Extensions) != 3 {
 		t.Errorf("len(Extensions) = %d, want 3", len(p.Extensions))
 	}
+	if len(p.ExtensionsExclude) != 0 {
+		t.Errorf("len(ExtensionsExclude) = %d, want 0", len(p.ExtensionsExclude))
+	}
+	if p.ExtensionsReset {
+		t.Errorf("ExtensionsReset = true, want false for plain-list input")
+	}
 	if p.Coverage != CoverageXdebug {
 		t.Errorf("Coverage = %q, want xdebug", p.Coverage)
 	}
@@ -60,27 +66,49 @@ func TestFromEnvDefaults(t *testing.T) {
 
 func TestParseExtensions(t *testing.T) {
 	tests := []struct {
-		input string
-		want  []string
+		name        string
+		input       string
+		wantInclude []string
+		wantExclude []string
+		wantReset   bool
 	}{
-		{"mbstring, redis, curl", []string{"curl", "mbstring", "redis"}},
-		{"Redis, MBSTRING, curl", []string{"curl", "mbstring", "redis"}},
-		{" redis , redis , curl ", []string{"curl", "redis"}},
-		{"", nil},
-		{"none", nil},
+		{"empty", "", nil, nil, false},
+		{"plain list", "mbstring, redis, curl", []string{"curl", "mbstring", "redis"}, nil, false},
+		{"case and whitespace", " Redis , MBSTRING , curl ", []string{"curl", "mbstring", "redis"}, nil, false},
+		{"dedupe", "redis, redis, curl", []string{"curl", "redis"}, nil, false},
+		{"single exclusion", ":opcache", nil, []string{"opcache"}, false},
+		{"exclusion with includes", "redis, :opcache, curl", []string{"curl", "redis"}, []string{"opcache"}, false},
+		{"none alone", "none", nil, nil, true},
+		{"none then include", "none, redis, curl", []string{"curl", "redis"}, nil, true},
+		{"none then include and exclude", "none, redis, :opcache", []string{"redis"}, []string{"opcache"}, true},
+		{"none anywhere resets before it", "redis, none, curl", []string{"curl"}, nil, true},
 	}
 	for _, tt := range tests {
-		got := ParseExtensions(tt.input)
-		if len(got) != len(tt.want) {
-			t.Errorf("ParseExtensions(%q) = %v, want %v", tt.input, got, tt.want)
-			continue
-		}
-		for i := range got {
-			if got[i] != tt.want[i] {
-				t.Errorf("ParseExtensions(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+		t.Run(tt.name, func(t *testing.T) {
+			incl, excl, reset := ParseExtensions(tt.input)
+			if !equalStringSlice(incl, tt.wantInclude) {
+				t.Errorf("include = %v, want %v", incl, tt.wantInclude)
 			}
+			if !equalStringSlice(excl, tt.wantExclude) {
+				t.Errorf("exclude = %v, want %v", excl, tt.wantExclude)
+			}
+			if reset != tt.wantReset {
+				t.Errorf("reset = %v, want %v", reset, tt.wantReset)
+			}
+		})
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
 		}
 	}
+	return true
 }
 
 func TestParseIniValues(t *testing.T) {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -160,6 +160,97 @@ func TestHashDeterminism(t *testing.T) {
 	}
 }
 
+func TestFromEnvPHPTSDefaults(t *testing.T) {
+	t.Setenv("INPUT_PHPTS", "")
+	t.Setenv("RUNNER_OS", "Linux")
+	t.Setenv("RUNNER_ARCH", "X64")
+	p, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if p.ThreadSafety != "nts" {
+		t.Errorf("ThreadSafety = %q, want nts", p.ThreadSafety)
+	}
+}
+
+func TestFromEnvPHPTSZTS(t *testing.T) {
+	t.Setenv("INPUT_PHPTS", "zts")
+	t.Setenv("RUNNER_OS", "Linux")
+	t.Setenv("RUNNER_ARCH", "X64")
+	p, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if p.ThreadSafety != "zts" {
+		t.Errorf("ThreadSafety = %q, want zts", p.ThreadSafety)
+	}
+}
+
+func TestFromEnvUpdate(t *testing.T) {
+	t.Setenv("INPUT_UPDATE", "true")
+	t.Setenv("RUNNER_OS", "Linux")
+	t.Setenv("RUNNER_ARCH", "X64")
+	p, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !p.Update {
+		t.Errorf("Update = false, want true")
+	}
+}
+
+func TestFromEnvUpdateDefault(t *testing.T) {
+	t.Setenv("INPUT_UPDATE", "")
+	t.Setenv("RUNNER_OS", "Linux")
+	t.Setenv("RUNNER_ARCH", "X64")
+	p, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if p.Update {
+		t.Errorf("Update default = true, want false")
+	}
+}
+
+func TestFromEnvFailFast(t *testing.T) {
+	t.Setenv("INPUT_FAIL-FAST", "true")
+	t.Setenv("RUNNER_OS", "Linux")
+	t.Setenv("RUNNER_ARCH", "X64")
+	p, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !p.FailFast {
+		t.Errorf("FailFast = false, want true")
+	}
+}
+
+func TestFromEnvIniFileDefault(t *testing.T) {
+	t.Setenv("INPUT_INI-FILE", "")
+	t.Setenv("RUNNER_OS", "Linux")
+	t.Setenv("RUNNER_ARCH", "X64")
+	p, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if p.IniFile != "production" {
+		t.Errorf("IniFile default = %q, want production", p.IniFile)
+	}
+}
+
+func TestFromEnvIniFileDevelopment(t *testing.T) {
+	t.Setenv("INPUT_INI-FILE", "development")
+	t.Setenv("RUNNER_OS", "Linux")
+	t.Setenv("RUNNER_ARCH", "X64")
+	p, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if p.IniFile != "development" {
+		t.Errorf("IniFile = %q, want development", p.IniFile)
+	}
+}
+
 func TestNormalizeArch(t *testing.T) {
 	tests := map[string]string{
 		"X64":     "x86_64",

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -34,15 +34,17 @@ type Result struct {
 	Tool Matrix
 }
 
-// ExpandPHPMatrix expands php.yaml's abi_matrix into concrete cells.
+// ExpandPHPMatrix expands php.yaml's per-version abi_matrix into concrete
+// build cells. Only versions with `sources:` set contribute cells — the rest
+// encode compat intent and are intentionally skipped here.
 func ExpandPHPMatrix(spec *catalog.PHPSpec) []MatrixCell {
-	cells := make([]MatrixCell, 0, len(spec.Versions)*len(spec.ABIMatrix.OS)*len(spec.ABIMatrix.Arch)*len(spec.ABIMatrix.TS))
-	for _, ver := range spec.Versions {
-		for _, osName := range spec.ABIMatrix.OS {
-			for _, arch := range spec.ABIMatrix.Arch {
-				for _, ts := range spec.ABIMatrix.TS {
+	var cells []MatrixCell
+	for _, target := range spec.BuildTargets() {
+		for _, osName := range target.Spec.ABIMatrix.OS {
+			for _, arch := range target.Spec.ABIMatrix.Arch {
+				for _, ts := range target.Spec.ABIMatrix.TS {
 					cells = append(cells, MatrixCell{
-						Version: ver,
+						Version: target.Version,
 						OS:      osName,
 						Arch:    arch,
 						TS:      ts,

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -11,11 +11,16 @@ import (
 
 func TestExpandPHPMatrix(t *testing.T) {
 	spec := &catalog.PHPSpec{
-		Versions: []string{"8.4"},
-		ABIMatrix: catalog.ABIMatrix{
-			OS:   []string{"linux"},
-			Arch: []string{"x86_64"},
-			TS:   []string{"nts"},
+		Versions: map[string]*catalog.PHPVersionSpec{
+			"8.4": {
+				BundledExtensions: []string{"mbstring"},
+				Sources:           &catalog.PHPSource{URL: "https://example/php-{version}.tar.xz"},
+				ABIMatrix: catalog.ABIMatrix{
+					OS:   []string{"linux"},
+					Arch: []string{"x86_64"},
+					TS:   []string{"nts"},
+				},
+			},
 		},
 	}
 
@@ -33,17 +38,56 @@ func TestExpandPHPMatrix(t *testing.T) {
 
 func TestExpandPHPMatrixMulti(t *testing.T) {
 	spec := &catalog.PHPSpec{
-		Versions: []string{"8.3", "8.4"},
-		ABIMatrix: catalog.ABIMatrix{
-			OS:   []string{"linux"},
-			Arch: []string{"x86_64", "aarch64"},
-			TS:   []string{"nts"},
+		Versions: map[string]*catalog.PHPVersionSpec{
+			"8.3": {
+				BundledExtensions: []string{"mbstring"},
+				Sources:           &catalog.PHPSource{URL: "https://example/php-{version}.tar.xz"},
+				ABIMatrix: catalog.ABIMatrix{
+					OS:   []string{"linux"},
+					Arch: []string{"x86_64", "aarch64"},
+					TS:   []string{"nts"},
+				},
+			},
+			"8.4": {
+				BundledExtensions: []string{"mbstring"},
+				Sources:           &catalog.PHPSource{URL: "https://example/php-{version}.tar.xz"},
+				ABIMatrix: catalog.ABIMatrix{
+					OS:   []string{"linux"},
+					Arch: []string{"x86_64", "aarch64"},
+					TS:   []string{"nts"},
+				},
+			},
 		},
 	}
 	// 2 versions × 1 OS × 2 arch × 1 TS = 4 cells
 	cells := ExpandPHPMatrix(spec)
 	if len(cells) != 4 {
 		t.Fatalf("len(cells) = %d, want 4", len(cells))
+	}
+}
+
+func TestExpandPHPMatrixSkipsCompatOnlyVersions(t *testing.T) {
+	spec := &catalog.PHPSpec{
+		Versions: map[string]*catalog.PHPVersionSpec{
+			"8.1": {BundledExtensions: []string{"mbstring"}}, // no sources → compat only
+			"8.4": {
+				BundledExtensions: []string{"mbstring"},
+				Sources:           &catalog.PHPSource{URL: "https://example/php-{version}.tar.xz"},
+				ABIMatrix: catalog.ABIMatrix{
+					OS:   []string{"linux"},
+					Arch: []string{"x86_64"},
+					TS:   []string{"nts"},
+				},
+			},
+		},
+	}
+
+	cells := ExpandPHPMatrix(spec)
+	if len(cells) != 1 {
+		t.Fatalf("len(cells) = %d, want 1 (compat-only versions must be skipped)", len(cells))
+	}
+	if cells[0].Version != "8.4" {
+		t.Errorf("expected only 8.4 cell, got %+v", cells[0])
 	}
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -54,7 +54,7 @@ func Resolve(p *plan.Plan, lf *lockfile.Lockfile, cat *catalog.Catalog) (*Resolu
 	}
 
 	for _, extName := range p.Extensions {
-		if cat.IsBundled(extName) {
+		if cat.IsBundled(p.PHPVersion, extName) {
 			continue
 		}
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -115,7 +115,7 @@ func Resolve(p *plan.Plan, lf *lockfile.Lockfile, cat *catalog.Catalog) (*Resolu
 	if len(p.Tools) > 0 {
 		msg := fmt.Sprintf("tools input is not yet supported (requested: %s); will be ignored", strings.Join(p.Tools, ","))
 		if p.FailFast {
-			return nil, fmt.Errorf("%s", msg)
+			return nil, fmt.Errorf("%s (fail-fast)", msg)
 		}
 		res.Warnings = append(res.Warnings, "::warning::"+msg)
 	}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -28,6 +28,20 @@ func Resolve(p *plan.Plan, lf *lockfile.Lockfile, cat *catalog.Catalog) (*Resolu
 
 	phpKey := lockfile.PHPBundleKey(p.PHPVersion, p.OS, p.Arch, p.ThreadSafety)
 	phpDigest, ok := lf.Lookup(phpKey)
+	if !ok && p.ThreadSafety == "zts" {
+		// Fall back to NTS.
+		ntsKey := lockfile.PHPBundleKey(p.PHPVersion, p.OS, p.Arch, "nts")
+		if ntsDigest, ok2 := lf.Lookup(ntsKey); ok2 {
+			if p.FailFast {
+				return nil, fmt.Errorf("PHP %s ZTS for %s/%s not in lockfile (fail-fast)", p.PHPVersion, p.OS, p.Arch)
+			}
+			phpKey = ntsKey
+			phpDigest = ntsDigest
+			ok = true
+			res.Warnings = append(res.Warnings,
+				fmt.Sprintf("::warning::PHP %s ZTS not available for %s/%s; falling back to NTS", p.PHPVersion, p.OS, p.Arch))
+		}
+	}
 	if !ok {
 		return nil, fmt.Errorf("PHP %s for %s/%s/%s not found in lockfile", p.PHPVersion, p.OS, p.Arch, p.ThreadSafety)
 	}
@@ -99,7 +113,11 @@ func Resolve(p *plan.Plan, lf *lockfile.Lockfile, cat *catalog.Catalog) (*Resolu
 	}
 
 	if len(p.Tools) > 0 {
-		res.Warnings = append(res.Warnings, "tools input is not yet supported in this version; tools will be ignored")
+		msg := fmt.Sprintf("tools input is not yet supported (requested: %s); will be ignored", strings.Join(p.Tools, ","))
+		if p.FailFast {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		res.Warnings = append(res.Warnings, "::warning::"+msg)
 	}
 
 	return res, nil

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -12,7 +12,9 @@ import (
 func testCatalog() *catalog.Catalog {
 	return &catalog.Catalog{
 		PHP: &catalog.PHPSpec{
-			BundledExtensions: []string{"mbstring", "curl", "intl", "zip"},
+			Versions: map[string]*catalog.PHPVersionSpec{
+				"8.4.6": {BundledExtensions: []string{"mbstring", "curl", "intl", "zip"}},
+			},
 		},
 		Extensions: map[string]*catalog.ExtensionSpec{
 			"redis":    {Name: "redis", Kind: catalog.ExtensionKindPECL},

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/buildrush/setup-php/internal/catalog"
@@ -115,5 +116,92 @@ func TestResolveToolsWarning(t *testing.T) {
 	}
 	if len(res.Warnings) == 0 {
 		t.Error("Resolve() should emit a warning for tools in Phase 1")
+	}
+}
+
+func TestResolveZTSFallback(t *testing.T) {
+	// Lockfile has NTS but not ZTS.
+	lf := testLockfile()
+	// testLockfile's "redis" and ZTS entries aren't relevant here; just verify the
+	// core fallback semantics.
+	cat := testCatalog()
+
+	p := &plan.Plan{
+		PHPVersion:   "8.4.6",
+		OS:           "linux",
+		Arch:         "x86_64",
+		ThreadSafety: "zts",
+		FailFast:     false,
+	}
+	res, err := Resolve(p, lf, cat)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.PHPCore.Digest != "sha256:phpdigest" {
+		t.Errorf("ZTS should fall back to NTS; got digest %q", res.PHPCore.Digest)
+	}
+	found := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "ZTS not available") && strings.Contains(w, "falling back to NTS") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ZTS fallback warning, got %v", res.Warnings)
+	}
+}
+
+func TestResolveZTSFallbackFailFast(t *testing.T) {
+	lf := testLockfile()
+	cat := testCatalog()
+	p := &plan.Plan{
+		PHPVersion:   "8.4.6",
+		OS:           "linux",
+		Arch:         "x86_64",
+		ThreadSafety: "zts",
+		FailFast:     true,
+	}
+	_, err := Resolve(p, lf, cat)
+	if err == nil {
+		t.Fatal("expected hard error under fail-fast: true, got nil")
+	}
+	if !strings.Contains(err.Error(), "ZTS") {
+		t.Errorf("error should mention ZTS; got %v", err)
+	}
+}
+
+func TestResolveZTSUnresolvable(t *testing.T) {
+	// Neither ZTS nor NTS present for the requested version → hard error regardless of FailFast.
+	lf := &lockfile.Lockfile{Bundles: map[string]string{}}
+	cat := testCatalog()
+	p := &plan.Plan{
+		PHPVersion:   "8.4.6",
+		OS:           "linux",
+		Arch:         "x86_64",
+		ThreadSafety: "zts",
+		FailFast:     false,
+	}
+	_, err := Resolve(p, lf, cat)
+	if err == nil {
+		t.Fatal("expected hard error when neither ZTS nor NTS available")
+	}
+}
+
+func TestResolveToolsWarningFailFast(t *testing.T) {
+	p := &plan.Plan{
+		PHPVersion:   "8.4.6",
+		OS:           "linux",
+		Arch:         "x86_64",
+		ThreadSafety: "nts",
+		Tools:        []string{"composer"},
+		FailFast:     true,
+	}
+	_, err := Resolve(p, testLockfile(), testCatalog())
+	if err == nil {
+		t.Fatal("expected hard error under fail-fast: true with tools input")
+	}
+	if !strings.Contains(err.Error(), "composer") {
+		t.Errorf("error should mention the requested tool; got %v", err)
 	}
 }

--- a/test/smoke/compat.sh
+++ b/test/smoke/compat.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# test/smoke/compat.sh — shivammathur/setup-php@v2 drop-in compatibility scenario.
+#
+# Exercises the full phpup runtime path with v2-shaped input:
+#   extensions:  "redis, :opcache"   (include + exclusion)
+#   ini-values:  "memory_limit=256M, date.timezone=Europe/Berlin"
+#                (user overrides both the compat defaults: memory_limit=-1, date.timezone=UTC)
+#   coverage:    "xdebug"
+#
+# Pre-reqs:
+#   - phpup binary on PATH (or override with PHPUP=... env var)
+#   - the PHP 8.4 bundle already built and pushed to GHCR
+#     (OR: BUILDRUSH_OFFLINE_DIR pointing at a pre-extracted bundle layout)
+#   - GITHUB_TOKEN exported if pulling from GHCR
+#   - running on linux/x86_64
+
+set -euo pipefail
+
+PHPUP="${PHPUP:-phpup}"
+
+if ! command -v "$PHPUP" >/dev/null 2>&1; then
+  echo "FAIL: $PHPUP not on PATH; build with 'make build' and add ./bin to PATH" >&2
+  exit 2
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Fake GitHub Actions env
+export BUILDRUSH_DIR="$WORK"
+export GITHUB_ENV="$WORK/env"
+export GITHUB_OUTPUT="$WORK/output"
+export GITHUB_PATH="$WORK/path"
+: > "$GITHUB_ENV"; : > "$GITHUB_OUTPUT"; : > "$GITHUB_PATH"
+
+# INPUT_* env vars matching how GitHub Actions materializes action.yml inputs.
+# Our phpup reads INPUT_<NAME-UPPERCASED> where - stays - (not _).
+export "INPUT_PHP-VERSION=8.4"
+export "INPUT_EXTENSIONS=redis, :opcache"
+export "INPUT_INI-VALUES=memory_limit=256M, date.timezone=Europe/Berlin"
+export INPUT_COVERAGE=xdebug
+export "INPUT_FAIL-FAST=false"
+export RUNNER_OS=Linux
+export RUNNER_ARCH=X64
+
+echo "==== running $PHPUP ===="
+"$PHPUP"
+
+PHP_BIN="$WORK/core/usr/local/bin/php"
+if [ ! -x "$PHP_BIN" ]; then
+  echo "FAIL: expected php binary at $PHP_BIN not found" >&2
+  ls -la "$WORK" >&2 || true
+  exit 1
+fi
+
+echo "==== php -v ===="
+"$PHP_BIN" -v
+
+echo "==== php -m ===="
+MODULES=$("$PHP_BIN" -m)
+echo "$MODULES"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+echo "==== assertions ===="
+
+# redis was explicitly requested → must be loaded
+echo "$MODULES" | grep -qi "^redis$"   || fail "redis not loaded"
+
+# xdebug was requested via coverage:xdebug → must be loaded
+echo "$MODULES" | grep -qi "^xdebug$"  || fail "xdebug not loaded"
+
+# opcache was excluded via :opcache. In v2-compat semantics, a :ext exclusion
+# means the extension should NOT be active. Our disable fragments are audit-
+# trail only (compiled-in extensions still load); this assertion is skipped
+# until we have a mechanism to prevent compile-time extensions from loading.
+# For now, just make noise if opcache IS loaded so the gap stays visible.
+if echo "$MODULES" | grep -qi "^Zend OPcache$"; then
+  echo "NOTE: opcache still loaded despite :opcache exclusion (known compat gap — compile-time extras not disabled)" >&2
+fi
+
+# ini-values merge check: user override wins over compat default
+MEMORY=$("$PHP_BIN" -r 'echo ini_get("memory_limit");')
+[ "$MEMORY" = "256M" ] || fail "memory_limit=$MEMORY, want 256M (user should override compat default -1)"
+
+TZ=$("$PHP_BIN" -r 'echo ini_get("date.timezone");')
+[ "$TZ" = "Europe/Berlin" ] || fail "date.timezone=$TZ, want Europe/Berlin (user should override compat default UTC)"
+
+# php-version output is full X.Y.Z. GITHUB_OUTPUT uses multi-line delim format:
+#   php-version<<ghadelimiter_<rand>
+#   8.4.5
+#   ghadelimiter_<rand>
+# Parse out the value line.
+VERSION=$(awk '/^php-version<</{getline; print; exit}' "$GITHUB_OUTPUT")
+if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+  fail "php-version output is not X.Y.Z; got:
+$(cat "$GITHUB_OUTPUT")"
+fi
+
+echo "==== compat smoke PASS ===="

--- a/test/smoke/compat.sh
+++ b/test/smoke/compat.sh
@@ -10,7 +10,6 @@
 # Pre-reqs:
 #   - phpup binary on PATH (or override with PHPUP=... env var)
 #   - the PHP 8.4 bundle already built and pushed to GHCR
-#     (OR: BUILDRUSH_OFFLINE_DIR pointing at a pre-extracted bundle layout)
 #   - GITHUB_TOKEN exported if pulling from GHCR
 #   - running on linux/x86_64
 


### PR DESCRIPTION
## Summary

First slice of Phase 2: drop-in compatibility with `shivammathur/setup-php@v2` for the existing PHP 8.4 / linux-x86_64 / ubuntu-24.04 target, without expanding the build matrix.

- **Audit:** pinned compat reference in `docs/compat-matrix.md` at v2 commit `accd6127` and Ondrej PPA snapshot `2026-04-11`.
- **`internal/compat` package:** single source of truth for v2 behavior — `UnimplementedInputWarning`, `DefaultIniValues` (unconditional Linux defaults: `date.timezone=UTC`, `memory_limit=-1`), `BundledExtensions` (per-version 8.1–8.5, lowercase-normalized). Backed by golden files that preserve raw `php -m` output for audit.
- **`action.yml` / `internal/plan`:** all v2 inputs declared — `phpts`, `update`, `fail-fast`, `ini-file` added with matching defaults. Parsed + warned when set to values we can't implement (e.g. `update`).
- **Extension syntax:** `:ext` exclusion and `none` reset supported (matches v2). 14 parser test cases.
- **`internal/compose`:** user-supplied `ini-values` layer on top of compat defaults; disable fragments written for excluded/reset-implied extensions.
- **`internal/resolve`:** ZTS→NTS soft fallback with `::warning::`; `fail-fast: true` promotes soft fallbacks (ZTS missing, unsupported tools) to hard errors.
- **`cmd/phpup/main.go`:** wired end-to-end. `php-version` output now emits the full resolved `X.Y.Z`. User input `8.4.6` normalizes to `8.4` for compat lookups.
- **Catalog:** `catalog/php.yaml` restructured to versioned layout with `bundled_extensions` for 8.1–8.5; only 8.4 has `sources:` + `abi_matrix:` (others encode compat intent for future build slices). Cross-package drift test guards catalog vs. `compat` package.
- **Smoke:** `test/smoke/compat.sh` exercises the full flow (exclusions, user ini-value overrides, coverage).

## Deferred (out of scope for this slice)

- **T12 (builder flag alignment)** — aligning the compiled-in extension set with v2's Ondrej baseline requires local Docker iteration. Concrete flag diff and verification recipe at `docs/superpowers/specs/2026-04-17-phase2-t12-handoff.md`. Ships in a follow-up; the current 8.4 bundle is a superset of v2's bundled set for the extensions it already has.
- **Matrix expansion** (8.1/8.2/8.3/8.5 builds, aarch64, ubuntu-22.04) — subsequent Phase 2 slices.
- **Automated v2-vs-ours compat harness** — planned follow-up once ≥2 PHP versions build.
- **Runtime disabling of compile-time extensions** (e.g. `extensions: :opcache` actually preventing opcache from loading) — documented gap; follow-up issue.

## Test plan

- [x] `make check` green locally (gofmt, vet, golangci-lint, `go test -race -cover`, node tests, build) on every commit
- [x] `internal/compat` at 100% coverage; `internal/catalog` 88.3% (up from 58.2%); every touched package ≥85%
- [x] 14 extension-syntax test cases, 6 bundled-extension version subtests, 4 compute-disabled cases, 7 plan-input-parsing cases
- [ ] CI `make check` on this PR
- [ ] Manual: `bash -n test/smoke/compat.sh` (syntax) + `shellcheck` clean — confirmed locally
- [ ] Manual after T12 lands: `make bundle-php PHP_VERSION=8.4 && test/smoke/compat.sh`

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-17-phase2-compat-slice-design.md`
- Audit: `docs/compat-matrix.md`
- T12 hand-off: `docs/superpowers/specs/2026-04-17-phase2-t12-handoff.md`

## Release

Conventional commits throughout — release-please picks `v0.2.0-alpha.1` when this merges.