### PR TITLE
fix(workflows): grant write permissions on each wrapper's pipeline job

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -13,6 +13,11 @@ on:
 
 jobs:
   pipeline:
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/plan-and-build.yml
     with:
       force: ${{ inputs.force }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,11 @@ on:
 
 jobs:
   pipeline:
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/plan-and-build.yml
     with:
       force: false

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   pipeline:
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/plan-and-build.yml
     with:
       force: false

--- a/.github/workflows/security-rebuild.yml
+++ b/.github/workflows/security-rebuild.yml
@@ -5,6 +5,11 @@ on:
 
 jobs:
   pipeline:
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/plan-and-build.yml
     with:
       force: true


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by PR #22 (the plan-and-build refactor).

The reusable \`plan-and-build.yml\` declares write permissions for \`contents\`/\`packages\`/\`pull-requests\`/\`id-token\` at the workflow level, but GitHub Actions does not auto-grant those permissions to the caller. The caller must explicitly grant them on the job that does the \`workflow_call\`. This repo's default \`GITHUB_TOKEN\` is restrictive (\`contents: read, packages: read, pull-requests: none, id-token: none\`), so every invocation of \`manual.yml\` / \`nightly.yml\` / \`security-rebuild.yml\` (and the push-to-main path of \`on-push.yml\`) fails at startup with:

> The workflow is requesting 'contents: write, packages: write, pull-requests: write, id-token: write', but is only allowed 'contents: read, packages: read, pull-requests: none, id-token: none'.

This was first surfaced when triggering \`manual.yml\` post-v1.3.0 to drive the T12 bundle rebuild.

## Fix

Add a job-level \`permissions:\` block on each wrapper's \`pipeline\` job, mirroring the workflow-level permissions block that was on the pre-refactor \`on-push.yml\`.

## Files

- \`.github/workflows/on-push.yml\`
- \`.github/workflows/manual.yml\`
- \`.github/workflows/nightly.yml\`
- \`.github/workflows/security-rebuild.yml\`

## Test plan

- [x] \`make check\` green locally
- [x] \`prettier --check\` clean on all four files
- [ ] CI integration-test on PR
- [ ] Post-merge: \`gh workflow run manual.yml -f force=true -f push=true\` should now actually start (instead of \`startup_failure\`) and drive the T12 bundle rebuild end-to-end