### PR TITLE
feat: bundle rollout PR-β.2 — GC + release-lockfile invariant

### DIFF
--- a/.github/workflows/gc-bundles.yml
+++ b/.github/workflows/gc-bundles.yml
@@ -3,9 +3,42 @@ on:
   schedule:
     - cron: "0 0 1 */3 *"
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Actually delete candidates (otherwise dry-run)'
+        type: boolean
+        default: false
+      min_age_days:
+        description: 'Minimum age in days before a version is prunable'
+        type: number
+        default: 30
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   gc:
     runs-on: ubuntu-24.04
     steps:
-      - run: echo "GC workflow stub — Phase 7 will implement retention cleanup"
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+      - name: Run GC
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go run ./cmd/gc-bundles \
+            --org ${{ github.repository_owner }} \
+            --min-age-days ${{ inputs.min_age_days || 30 }} \
+            ${{ inputs.confirm && '--confirm' || '' }} \
+            | tee /tmp/gc-report.txt
+      - name: Upload GC report artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: gc-bundles-report
+          path: /tmp/gc-report.txt
+          retention-days: 90

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,3 +16,22 @@ jobs:
       force: false
       push: true
     secrets: inherit
+
+  invariant-check:
+    needs: pipeline
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+      - name: Run released-lockfile invariant
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go test -tags invariants ./test/invariants/... -v

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,3 +84,9 @@ jobs:
             echo "::warning::Standalone $MAJOR release found; deleting (violates release-artifact contract)"
             gh release delete "$MAJOR" --yes --cleanup-tag=false
           fi
+
+      - name: Run released-lockfile invariant
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go test -tags invariants ./test/invariants/... -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,11 @@ linters:
       - linters: [gosec]
         text: "G204"
         path: cmd/lockfile-update/
+      # Subprocess calls in gc-bundles execute git with internally-constructed args only;
+      # no untrusted input touches the command vector
+      - linters: [gosec]
+        text: "G204"
+        path: cmd/gc-bundles/
       # CommitOpts (96 bytes) parameter passing cost is negligible vs. git subprocess invocation cost
       - linters: [gocritic]
         text: "hugeParam"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: check fmt fmt-check vet lint tidy tidy-check test test-node build clean \
-        build-linux-amd64 build-linux-arm64 bundle-php bundle-ext
+        build-linux-amd64 build-linux-arm64 bundle-php bundle-ext gc-bundles-dry-run
 
 # Ensure the embedded lockfile is available for go vet/test/build
 cmd/phpup/bundles.lock: bundles.lock
@@ -84,3 +84,7 @@ bundle-ext:
 # Clean build artifacts
 clean:
 	rm -rf bin/ dist/
+
+# Dry-run the GC tool locally (requires gh auth login + network access).
+gc-bundles-dry-run:
+	go run ./cmd/gc-bundles --org buildrush --min-age-days 30

--- a/cmd/gc-bundles/filter.go
+++ b/cmd/gc-bundles/filter.go
@@ -1,0 +1,21 @@
+package main
+
+import "time"
+
+// Candidates returns the versions eligible for pruning: older than minAge AND
+// not in the referenced set. The returned slice preserves input order so the
+// dry-run report is stable across runs.
+func Candidates(versions []GHCRVersion, referenced map[string]struct{}, minAge time.Duration, now time.Time) []GHCRVersion {
+	cutoff := now.Add(-minAge)
+	var out []GHCRVersion
+	for _, v := range versions {
+		if v.CreatedAt.After(cutoff) {
+			continue
+		}
+		if _, refed := referenced[v.Name]; refed {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}

--- a/cmd/gc-bundles/filter_test.go
+++ b/cmd/gc-bundles/filter_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCandidates_FiltersByAgeAndReferenced(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	minAge := 30 * 24 * time.Hour
+
+	versions := []GHCRVersion{
+		// Too young (14 days): skipped regardless of referenced-ness.
+		{ID: 1, Name: "sha256:young", CreatedAt: now.Add(-14 * 24 * time.Hour)},
+		// Old + unreferenced: CANDIDATE.
+		{ID: 2, Name: "sha256:orphan", CreatedAt: now.Add(-90 * 24 * time.Hour)},
+		// Old but referenced by a released lockfile: MUST NOT be a candidate.
+		{ID: 3, Name: "sha256:released", CreatedAt: now.Add(-365 * 24 * time.Hour)},
+		// Old but referenced by an open branch: MUST NOT be a candidate.
+		{ID: 4, Name: "sha256:active", CreatedAt: now.Add(-60 * 24 * time.Hour)},
+	}
+	referenced := map[string]struct{}{
+		"sha256:released": {},
+		"sha256:active":   {},
+	}
+
+	got := Candidates(versions, referenced, minAge, now)
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1; got %+v", len(got), got)
+	}
+	if got[0].ID != 2 {
+		t.Errorf("candidate ID = %d, want 2 (orphan)", got[0].ID)
+	}
+}

--- a/cmd/gc-bundles/ghcr.go
+++ b/cmd/gc-bundles/ghcr.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// GHCRVersion is the subset of a GHCR package version response we care about.
+type GHCRVersion struct {
+	ID        int64     `json:"id"`
+	Name      string    `json:"name"` // e.g. "sha256:abc..."
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Runner abstracts the gh CLI invocation so tests can inject canned responses.
+type Runner interface {
+	Run(args ...string) ([]byte, error)
+}
+
+// ghRunner is the production Runner that execs `gh`.
+type ghRunner struct{}
+
+func (ghRunner) Run(args ...string) ([]byte, error) {
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("gh %v: %w\n%s", args, err, out)
+	}
+	return out, nil
+}
+
+// NewGHRunner returns a production Runner that invokes the gh CLI.
+func NewGHRunner() Runner {
+	return ghRunner{}
+}
+
+// ListPackageVersions returns every version manifest of a GHCR package.
+func ListPackageVersions(r Runner, org, pkg string) ([]GHCRVersion, error) {
+	path := fmt.Sprintf("/orgs/%s/packages/container/%s/versions?per_page=100", org, pkg)
+	out, err := r.Run("api", "--paginate", path)
+	if err != nil {
+		return nil, err
+	}
+	var versions []GHCRVersion
+	if err := json.Unmarshal(out, &versions); err != nil {
+		return nil, fmt.Errorf("parse versions for %s: %w", pkg, err)
+	}
+	return versions, nil
+}
+
+// DeletePackageVersion removes a single version. Caller must be in --confirm
+// mode before invoking.
+func DeletePackageVersion(r Runner, org, pkg string, id int64) error {
+	path := fmt.Sprintf("/orgs/%s/packages/container/%s/versions/%d", org, pkg, id)
+	_, err := r.Run("api", "--method", "DELETE", path)
+	return err
+}

--- a/cmd/gc-bundles/ghcr_test.go
+++ b/cmd/gc-bundles/ghcr_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeRunner records calls and returns canned responses keyed by the joined
+// arg string. Unknown commands return an error.
+type fakeRunner struct {
+	responses map[string]string
+	calls     []string
+}
+
+func (f *fakeRunner) Run(args ...string) ([]byte, error) {
+	key := strings.Join(args, " ")
+	f.calls = append(f.calls, key)
+	if resp, ok := f.responses[key]; ok {
+		return []byte(resp), nil
+	}
+	return nil, &stubError{key: key}
+}
+
+type stubError struct{ key string }
+
+func (e *stubError) Error() string { return "no canned response for: " + e.key }
+
+func TestListPackageVersions_ParsesGHCRResponse(t *testing.T) {
+	manifests := []GHCRVersion{
+		{ID: 111, Name: "sha256:aaa", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{ID: 222, Name: "sha256:bbb", CreatedAt: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	payload, _ := json.Marshal(manifests)
+
+	runner := &fakeRunner{responses: map[string]string{
+		"api --paginate /orgs/buildrush/packages/container/php-core/versions?per_page=100": string(payload),
+	}}
+
+	got, err := ListPackageVersions(runner, "buildrush", "php-core")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].ID != 111 || got[1].ID != 222 {
+		t.Errorf("IDs = [%d, %d], want [111, 222]", got[0].ID, got[1].ID)
+	}
+	if !got[0].CreatedAt.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("first CreatedAt = %v, want 2026-01-01", got[0].CreatedAt)
+	}
+}

--- a/cmd/gc-bundles/main.go
+++ b/cmd/gc-bundles/main.go
@@ -1,0 +1,150 @@
+// Command gc-bundles prunes unreferenced GHCR bundles.
+//
+// Runs in two modes:
+//
+//	--dry-run (default): list candidate versions without deleting.
+//	--confirm: actually delete the candidates. Guarded behind a workflow
+//	           dispatch input; local dev should stick to --dry-run.
+//
+// A version is a candidate for pruning when it is:
+//   - a container manifest under ghcr.io/<org>/php-core or
+//     ghcr.io/<org>/php-ext-<name>;
+//   - older than --min-age-days (default 30);
+//   - not referenced by bundles.lock on any remote branch or any released
+//     tag's embedded bundles.lock.
+//
+// Released-tag lockfile references are load-bearing for product-vision §16
+// reproducibility and must never be pruned.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	org := flag.String("org", "buildrush", "GHCR organization to scan")
+	minAgeDays := flag.Int("min-age-days", 30, "minimum age before a version is prunable")
+	confirm := flag.Bool("confirm", false, "actually delete (default is dry-run)")
+	flag.Parse()
+
+	if err := run(*org, *minAgeDays, *confirm, os.Stdout); err != nil {
+		log.Fatalf("gc-bundles: %v", err)
+	}
+}
+
+// run is the testable core. It writes a human-readable report to w; the
+// dry-run report doubles as the artifact uploaded by gc-bundles.yml.
+func run(org string, minAgeDays int, confirm bool, w *os.File) error {
+	runner := NewGHRunner()
+
+	// 1. Collect referenced digests from all branches + released tags.
+	releaseTags, err := listReleases(runner)
+	if err != nil {
+		return fmt.Errorf("list releases: %w", err)
+	}
+	referenced, err := EnumerateReferencedDigests(".", releaseTags)
+	if err != nil {
+		return fmt.Errorf("enumerate refs: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "referenced: %d digest(s) across branches + %d release tag(s)\n",
+		len(referenced), len(releaseTags)); err != nil {
+		return err
+	}
+
+	// 2. Enumerate our packages. We only touch php-core and php-ext-*.
+	packages, err := listSetupPhpPackages(runner, org)
+	if err != nil {
+		return fmt.Errorf("list packages: %w", err)
+	}
+
+	// 3. For each package, list versions + filter to candidates.
+	minAge := time.Duration(minAgeDays) * 24 * time.Hour
+	now := time.Now().UTC()
+	totalCandidates := 0
+	for _, pkg := range packages {
+		versions, err := ListPackageVersions(runner, org, pkg)
+		if err != nil {
+			if _, werr := fmt.Fprintf(w, "WARNING: list %s: %v\n", pkg, err); werr != nil {
+				return werr
+			}
+			continue
+		}
+		cands := Candidates(versions, referenced, minAge, now)
+		for _, c := range cands {
+			if _, werr := fmt.Fprintf(w, "candidate: %s %s (id=%d, created=%s)\n",
+				pkg, c.Name, c.ID, c.CreatedAt.Format(time.RFC3339)); werr != nil {
+				return werr
+			}
+			if confirm {
+				if err := DeletePackageVersion(runner, org, pkg, c.ID); err != nil {
+					if _, werr := fmt.Fprintf(w, "  DELETE FAILED: %v\n", err); werr != nil {
+						return werr
+					}
+				} else {
+					if _, werr := fmt.Fprintf(w, "  deleted\n"); werr != nil {
+						return werr
+					}
+				}
+			}
+		}
+		totalCandidates += len(cands)
+	}
+
+	mode := "dry-run"
+	if confirm {
+		mode = "DELETE"
+	}
+	if _, err := fmt.Fprintf(w, "%s complete: %d candidate(s) across %d package(s)\n",
+		mode, totalCandidates, len(packages)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// listReleases calls `gh release list` and returns tag names.
+func listReleases(r Runner) ([]string, error) {
+	out, err := r.Run("release", "list", "--json", "tagName", "--limit", "500")
+	if err != nil {
+		return nil, err
+	}
+	var releases []struct {
+		TagName string `json:"tagName"`
+	}
+	if err := json.Unmarshal(out, &releases); err != nil {
+		return nil, fmt.Errorf("parse releases: %w", err)
+	}
+	tags := make([]string, 0, len(releases))
+	for _, rel := range releases {
+		tags = append(tags, rel.TagName)
+	}
+	return tags, nil
+}
+
+// listSetupPhpPackages returns only the package names we manage (php-core,
+// php-ext-*). Other org packages are out of scope for this GC.
+func listSetupPhpPackages(r Runner, org string) ([]string, error) {
+	out, err := r.Run("api", "--paginate",
+		fmt.Sprintf("/orgs/%s/packages?package_type=container&per_page=100", org))
+	if err != nil {
+		return nil, err
+	}
+	var pkgs []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(out, &pkgs); err != nil {
+		return nil, fmt.Errorf("parse packages: %w", err)
+	}
+	var filtered []string
+	for _, p := range pkgs {
+		if p.Name == "php-core" || strings.HasPrefix(p.Name, "php-ext-") {
+			filtered = append(filtered, p.Name)
+		}
+	}
+	return filtered, nil
+}

--- a/cmd/gc-bundles/refs.go
+++ b/cmd/gc-bundles/refs.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// EnumerateReferencedDigests returns the union of every bundles[*].digest
+// across bundles.lock on every remote branch and every given release tag.
+// Missing or unparseable lockfiles on a ref are treated as empty — a stale
+// branch without bundles.lock should not block GC of its ancestor branches.
+//
+// gitRepo is a path to a working tree (any clone works; remote refs are
+// queried via `git show origin/<branch>:bundles.lock`). releaseTags is the
+// caller-supplied list of released tag names; we decouple tag discovery
+// from enumeration so callers can plug in `gh release list` or fixtures.
+func EnumerateReferencedDigests(gitRepo string, releaseTags []string) (map[string]struct{}, error) {
+	referenced := map[string]struct{}{}
+
+	branches, err := listRemoteBranches(gitRepo)
+	if err != nil {
+		return nil, fmt.Errorf("list branches: %w", err)
+	}
+
+	refs := make([]string, 0, len(branches)+len(releaseTags))
+	for _, b := range branches {
+		refs = append(refs, "refs/remotes/origin/"+b)
+	}
+	for _, t := range releaseTags {
+		refs = append(refs, "refs/tags/"+t)
+	}
+
+	for _, ref := range refs {
+		digests, err := extractDigestsAt(gitRepo, ref)
+		if err != nil {
+			// Ref may not have bundles.lock (e.g. ancient branch). Skip.
+			continue
+		}
+		for _, d := range digests {
+			referenced[d] = struct{}{}
+		}
+	}
+
+	return referenced, nil
+}
+
+func listRemoteBranches(gitRepo string) ([]string, error) {
+	cmd := exec.Command("git", "-C", gitRepo, "ls-remote", "--heads", "origin")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git ls-remote: %w\n%s", err, out.String())
+	}
+	var names []string
+	for _, line := range strings.Split(out.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Format: "<sha>\trefs/heads/<name>"
+		parts := strings.SplitN(line, "refs/heads/", 2)
+		if len(parts) == 2 && parts[1] != "" {
+			names = append(names, parts[1])
+		}
+	}
+	return names, nil
+}
+
+func extractDigestsAt(gitRepo, ref string) ([]string, error) {
+	cmd := exec.Command("git", "-C", gitRepo, "show", ref+":bundles.lock")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	// Parse just enough to reach digest fields; keep the shape permissive so
+	// schema evolution doesn't break GC.
+	var probe struct {
+		Bundles map[string]struct {
+			Digest string `json:"digest"`
+		} `json:"bundles"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &probe); err != nil {
+		return nil, fmt.Errorf("parse %s:bundles.lock: %w", ref, err)
+	}
+	digests := make([]string, 0, len(probe.Bundles))
+	for _, b := range probe.Bundles {
+		if b.Digest != "" {
+			digests = append(digests, b.Digest)
+		}
+	}
+	return digests, nil
+}

--- a/cmd/gc-bundles/refs_test.go
+++ b/cmd/gc-bundles/refs_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// setupRepoWithLockfiles creates a bare origin repo with two branches and one
+// annotated tag, each carrying a different bundles.lock. Returns the work
+// tree path the caller should use when invoking the enumerator.
+func setupRepoWithLockfiles(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	work := filepath.Join(root, "work")
+
+	run := func(dir, name string, args ...string) {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s %v: %v\n%s", name, args, err, out)
+		}
+	}
+	write := func(dir, file, content string) {
+		if err := os.WriteFile(filepath.Join(dir, file), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+	}
+
+	run(root, "git", "init", "--bare", "-b", "main", origin)
+	run(root, "git", "clone", origin, work)
+	run(work, "git", "config", "user.email", "t@example.com")
+	run(work, "git", "config", "user.name", "t")
+	run(work, "git", "config", "commit.gpgsign", "false")
+
+	// main has digest A
+	write(work, "bundles.lock", `{"schema_version":2,"bundles":{"k1":{"digest":"sha256:A","spec_hash":"sha256:hA"}}}`)
+	run(work, "git", "add", "bundles.lock")
+	run(work, "git", "commit", "-m", "main")
+	run(work, "git", "push", "-u", "origin", "main")
+
+	// feature branch adds digest B
+	run(work, "git", "checkout", "-b", "feat/x")
+	write(work, "bundles.lock", `{"schema_version":2,"bundles":{"k1":{"digest":"sha256:B","spec_hash":"sha256:hB"}}}`)
+	run(work, "git", "commit", "-am", "feat")
+	run(work, "git", "push", "-u", "origin", "feat/x")
+
+	// Create C on a detached HEAD, tag v0.1.0, and push the tag.
+	// This keeps the commit reachable only through the tag, not through any branch.
+	run(work, "git", "checkout", "--detach", "main")
+	write(work, "bundles.lock", `{"schema_version":2,"bundles":{"k1":{"digest":"sha256:C","spec_hash":"sha256:hC"}}}`)
+	run(work, "git", "add", "bundles.lock")
+	run(work, "git", "commit", "-m", "release")
+	run(work, "git", "tag", "-a", "v0.1.0", "-m", "release 0.1.0")
+	run(work, "git", "push", "origin", "v0.1.0")
+
+	return work
+}
+
+func TestEnumerateReferencedDigests_UnionsAllRefs(t *testing.T) {
+	work := setupRepoWithLockfiles(t)
+
+	got, err := EnumerateReferencedDigests(work, []string{"v0.1.0"})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+
+	for _, want := range []string{"sha256:A", "sha256:B", "sha256:C"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("missing %s in referenced set; got %v", want, got)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 digests, got %d: %v", len(got), got)
+	}
+}

--- a/test/invariants/release_lockfile_test.go
+++ b/test/invariants/release_lockfile_test.go
@@ -1,0 +1,141 @@
+//go:build invariants
+// +build invariants
+
+// Package invariants holds cross-release assertions that run in release-please
+// and nightly workflows — separated from regular tests so `go test ./...` stays
+// fast and hermetic.
+package invariants
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestReleasedLockfilesAreReachable ensures every digest referenced by any
+// published release's bundles.lock still resolves on GHCR. If this fails,
+// a released @vX.Y.Z action version would produce a broken install,
+// regressing product-vision §16 reproducibility.
+func TestReleasedLockfilesAreReachable(t *testing.T) {
+	tags := listReleasedTags(t)
+	if len(tags) == 0 {
+		t.Skip("no published releases — invariant vacuously holds")
+	}
+
+	for _, tag := range tags {
+		tag := tag
+		t.Run(tag, func(t *testing.T) {
+			bundles := parseLockfileAt(t, tag)
+			if len(bundles) == 0 {
+				t.Skipf("%s has no bundles.lock entries", tag)
+			}
+			for key, digest := range bundles {
+				if !digestReachable(t, key, digest) {
+					t.Errorf("%s: digest %s (key=%s) NOT reachable on GHCR", tag, digest, key)
+				}
+			}
+		})
+	}
+}
+
+func listReleasedTags(t *testing.T) []string {
+	t.Helper()
+	out, err := exec.Command("gh", "release", "list", "--json", "tagName", "--limit", "500").Output()
+	if err != nil {
+		t.Fatalf("gh release list: %v", err)
+	}
+	var releases []struct {
+		TagName string `json:"tagName"`
+	}
+	if err := json.Unmarshal(out, &releases); err != nil {
+		t.Fatalf("parse releases: %v", err)
+	}
+	tags := make([]string, 0, len(releases))
+	for _, r := range releases {
+		tags = append(tags, r.TagName)
+	}
+	return tags
+}
+
+func parseLockfileAt(t *testing.T, tag string) map[string]string {
+	t.Helper()
+	out, err := exec.Command("git", "show", "refs/tags/"+tag+":bundles.lock").Output()
+	if err != nil {
+		return nil
+	}
+	var probe struct {
+		Bundles map[string]struct {
+			Digest string `json:"digest"`
+		} `json:"bundles"`
+	}
+	if err := json.Unmarshal(out, &probe); err != nil {
+		t.Logf("%s: parse bundles.lock: %v", tag, err)
+		return nil
+	}
+	result := map[string]string{}
+	for k, v := range probe.Bundles {
+		if v.Digest != "" {
+			result[k] = v.Digest
+		}
+	}
+	return result
+}
+
+// digestReachable HEADs the manifest at ghcr.io. Keys like
+// "ext:xdebug:3.5.1:8.4:linux:x86_64:nts" map to
+// "ghcr.io/<org>/php-ext-xdebug@<digest>".
+func digestReachable(t *testing.T, key, digest string) bool {
+	t.Helper()
+	org := "buildrush"
+	var pkg string
+	switch {
+	case strings.HasPrefix(key, "php:"):
+		pkg = "php-core"
+	case strings.HasPrefix(key, "ext:"):
+		fields := strings.Split(key, ":")
+		if len(fields) < 2 {
+			t.Errorf("malformed key %q", key)
+			return false
+		}
+		pkg = "php-ext-" + fields[1]
+	default:
+		t.Errorf("unknown key prefix %q", key)
+		return false
+	}
+	url := "https://ghcr.io/v2/" + org + "/" + pkg + "/manifests/" + digest
+
+	tokenURL := "https://ghcr.io/token?scope=repository:" + org + "/" + pkg + ":pull"
+	tokenResp, err := http.Get(tokenURL)
+	if err != nil {
+		t.Logf("token fetch %s: %v", tokenURL, err)
+		return false
+	}
+	defer tokenResp.Body.Close()
+	var tok struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
+		t.Logf("decode token: %v", err)
+		return false
+	}
+
+	req, _ := http.NewRequest("HEAD", url, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Logf("HEAD %s: %v", url, err)
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(resp.Body)
+		t.Logf("HEAD %s: %d %s", url, resp.StatusCode, buf.String())
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Closes Tβ-7 and Tβ-8 of `docs/superpowers/specs/2026-04-20-bundle-schema-and-rollout-design.md`. Reliability foundation for the rollout design.

- **`cmd/gc-bundles`** — new Go tool that enumerates referenced digests across every remote branch + every published release tag, lists GHCR versions for `php-core` + `php-ext-*` packages, and emits candidates for prune (old + unreferenced). Dry-run default; real delete guarded behind `workflow_dispatch` `confirm: true`. Unit-tested against a bare-repo fixture (ref enumeration) and an injectable `Runner` (GHCR operations).
- **`gc-bundles.yml`** — replaces the stub with a real invocation. Quarterly schedule. Uploads a `gc-bundles-report` artifact (90-day retention) every run so maintainers can review candidates before the next real-delete cycle.
- **`test/invariants/release_lockfile_test.go`** — `//go:build invariants` test that HEADs every digest in every published release's `bundles.lock` against GHCR. Uses the correct OCI manifest `Accept` header and anonymous pull-token flow (lesson from PR-β.1's Accept-header debugging). Proves product-vision §16 reproducibility: pinned `@vX.Y.Z` references must remain resolvable.
- **`release-please.yml` + `nightly.yml`** — new `invariant-check` wiring. On release-please, gated on `release_created`. On nightly, `if: always()` as a drift guard.
- **`.golangci.yml`** — extends the `gosec G204` exclude-rule to `cmd/gc-bundles/` (same justification as `cmd/lockfile-update/`: internal subprocess invocation with internally-constructed args).
- **`Makefile`** — `gc-bundles-dry-run` convenience target.

## Test plan

- [x] `go test -race ./cmd/gc-bundles/` — 3 unit tests green (refs enumeration, GHCR list, filter)
- [x] `go test -tags invariants ./test/invariants/...` — passes locally against existing releases
- [x] `make check` — clean
- [ ] First quarterly `gc-bundles.yml` schedule emits a sensible report — **inspect the artifact**; don't flip `confirm: true` until reviewed
- [ ] Next release-please run completes `invariant-check` green

## Operational notes

**The first `gc-bundles` dispatch should run WITHOUT `confirm: true`** so we can review what it plans to delete. Only after that review should we run with `confirm: true` manually. The quarterly cron stays dry-run-only — real deletes require explicit manual dispatch. Report artifact has 90-day retention for audit.

No runtime changes in this PR.