### PR TITLE
docs: close bundle-rollout spec Tβ-9 doc gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ for the full design.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
+### How PR CI handles bundle changes
+
+When a PR modifies `catalog/**` or `builders/**`, the build pipeline self-publishes: new bundles are pushed to GHCR and `bundles.lock` is committed **directly to the PR branch** under the `github-actions[bot]` identity. This lets the compat harness run against the bundles the PR actually needs. Practical implications (force-push etiquette, fork-PR handling, orphan GC) live in [CONTRIBUTING.md](CONTRIBUTING.md#ci-writes-to-your-pr-branch). Full design: [`docs/superpowers/specs/2026-04-20-bundle-schema-and-rollout-design.md`](docs/superpowers/specs/2026-04-20-bundle-schema-and-rollout-design.md).
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -197,6 +197,8 @@ ghcr.io/buildrush/php-tool-phpstan:1.11.0
 
 Tags are convenience pointers; digests are canonical. Consumers always resolve to a digest before pulling.
 
+The `bundles.lock` digest is sufficient to identify a bundle *uniquely on the wire*, but the runtime also consults the sidecar's `schema_version` (see §6.1) before composing — a bundle whose sidecar declares a lower `schema_version` than the runtime's `internal/version.MinBundleSchema(kind)` is rejected with a pointer to `docs/bundle-schema-changelog.md`. Schema version is therefore the *shape* contract on top of the digest's *bit-level* identity.
+
 ### 6.3 Why GHCR
 
 - **No anonymous pull rate limit** for public packages.
@@ -469,6 +471,12 @@ A flat JSON file, auto-generated and PR-merged, mapping canonical spec keys to O
 - **Deduplication**: an upstream mirror pull (e.g. PECL) that produces byte-identical output does not republish.
 - **Audit**: every published bundle has exactly one provenance — the build job whose output hashed to that digest.
 - **Rollback**: reverting the lockfile PR is a full rollback, because the old digests still exist on GHCR (they are never deleted by promotion).
+
+### 11.4 Lockfile updates and PR commit-back
+
+Bundle-affecting PRs (changes under `catalog/**` or `builders/**`) self-publish: the build pipeline pushes new bundles to GHCR and `cmd/lockfile-update --commit` commits the refreshed `bundles.lock` **back to the PR head ref** before the compat harness and integration tests run. This means the PR carries its own lockfile update — no separate bot PR against `main`, no "flag day" where a runtime assertion references a bundle shape that no published bundle satisfies.
+
+Each lockfile entry also carries a `spec_hash` alongside the `digest`. The planner uses `spec_hash` to detect whether a cell's inputs (catalog YAML, builder script, `builders/common/bundle-schema-version.env`) have drifted since the last build; if the spec-hash matches and the tag still resolves to the recorded digest, the planner skips the rebuild. See `docs/superpowers/specs/2026-04-20-bundle-schema-and-rollout-design.md` for the full rollout design and `cmd/gc-bundles` for how unreferenced digests are reaped.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-20-bundle-schema-and-rollout-design.md
+++ b/docs/superpowers/specs/2026-04-20-bundle-schema-and-rollout-design.md
@@ -370,13 +370,6 @@ If Tβ-2 is omitted, the env-file bump alone does not change the spec-hash and n
 - Post-PR-β, the core bundle digest has changed. All extension bundles rebuild implicitly because their spec-hash includes the core's digest per product-vision §6.2. The lockfile update lands in PR-β's own branch via the new flow — proving end-to-end.
 - `README.md` "Compatibility / CI flow" paragraph references this spec.
 
-### 7.1 Release
-
-- Conventional commits (`feat(workflows): …`, `feat(builders): …`, `feat(gc): …`, `feat(compose): schema assertion`, etc.).
-- `release-please` auto-cuts `v0.2.0-alpha.3` on merge.
-- Bundle digest for the 8.4 core changes again (new sidecar field). Extension bundles get rebuilt too (sidecar change → spec-hash change). Lockfile update lands in the slice's own PR via the new flow — dogfoods the fix.
-- `README.md` — add a one-paragraph "How PR CI handles bundle changes" section linking to this spec.
-
 ## 8. Open questions
 
 - **Fork-PR trusted-contributor workflow.** This spec fails-fast on fork PRs. A follow-up (Phase 7) should add `safe-to-build`-labelled `pull_request_target` pipeline with hardened permissions. The contract with this spec: fork PRs are visibly blocked, never silently broken.


### PR DESCRIPTION
## Summary

Three small doc gaps against `docs/superpowers/specs/2026-04-20-bundle-schema-and-rollout-design.md` Tβ-9 that didn't land with PR-β.1 (#33) or PR-β.2 (#34):

- **`README.md`** — new "How PR CI handles bundle changes" subsection under Contributing. Spec §7.1 and Tβ-9 both call for this README paragraph; PR-α put the equivalent detail only in `CONTRIBUTING.md`. Casual contributors read README first.
- **`docs/product-vision.md` §6.2** — appended a paragraph clarifying that `schema_version` is the shape contract layered on top of the digest's bit-level identity.
- **`docs/product-vision.md` §11** — added §11.4 "Lockfile updates and PR commit-back" documenting the self-publishing flow and the `spec_hash` field on lockfile entries.
- **spec itself** — removed a duplicated `### 7.1 Release` subsection introduced during the original write.

No code changes.

## Test plan

- [x] `make check` clean
- [ ] Manual doc read-through