### PR TITLE
feat: enable PHP 8.2 core + PECL rebuild (phase 2)

### DIFF
--- a/bundles.lock
+++ b/bundles.lock
@@ -1,50 +1,70 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-04-21T13:18:04.047830109Z",
+  "generated_at": "2026-04-21T13:32:46.420458911Z",
   "bundles": {
+    "ext:apcu:5.1.28:8.2:linux:x86_64:nts": {
+      "digest": "sha256:56a6715ae776fcda1c14c62f65f5e8a5b2220061b500ea494469d913341a1498",
+      "spec_hash": "sha256:b139ae05590eab94332520353a007501cafe2e662ae5c53c246644fd1c428bf9"
+    },
     "ext:apcu:5.1.28:8.3:linux:x86_64:nts": {
-      "digest": "sha256:daae7e2baffa2a28c6f06aa5aa11d247bcb23d048c7b2c0f1fd10ccc1b33b104",
-      "spec_hash": "sha256:9db2f0ee68e45fe0b699d87a9c990f75200411077dc2ba440a29f53bfdc47c4f"
+      "digest": "sha256:b82515bd8a3d31a1b4870bce23ddfb9551a079c0ed6f1a44ae1563edd631af94",
+      "spec_hash": "sha256:9769c6a1d9900d43eaa9b84ccee19743d80f5580f8a7e606c1ac4e604b03303b"
     },
     "ext:apcu:5.1.28:8.4:linux:x86_64:nts": {
-      "digest": "sha256:2db11f2e0c15293263ce04cdfaea83858c9ab56f4ffccac8dfd283a4ae7ecea6",
-      "spec_hash": "sha256:a56672436a38a66b678f87b4515a0ba4dd3cecaa6f9d08ecc5bd0cde1aae09fb"
+      "digest": "sha256:f1fe17b6a32b5cf5d575c60529a33492473be4534f5b7c48c4fbf681a905aab4",
+      "spec_hash": "sha256:419495ecfd326ad3dd79a33cd2c408b95d27ad06b7fa0004e881ea2e0acc510e"
     },
     "ext:apcu:5.1.28:8.5:linux:x86_64:nts": {
-      "digest": "sha256:3d30ff11e4735b4f699290838455c1f310fb592cfe3adc4f7135f8f8c00c4a84",
-      "spec_hash": "sha256:c50241f797be328ceb306dd11b0532b6ae9292a6bea875607c772582c3fbe30f"
+      "digest": "sha256:11b76f7aacd42275b8e82c92dbb1f8a35581b0cccd484f6b0f24b670de9c41ba",
+      "spec_hash": "sha256:5c6bec7ca1ee90e4fcd1b633c3246e5d960e3a5a54d059702cdb1a1904b63785"
+    },
+    "ext:pcov:1.0.12:8.2:linux:x86_64:nts": {
+      "digest": "sha256:0fb15603c909fddb110138d776ed2028fdb1aca126ae24896bf221c72e7651de",
+      "spec_hash": "sha256:196a28301d78ccd152fbdc9e10812d014478f56d0dbf733d9280dbaba983bd70"
     },
     "ext:pcov:1.0.12:8.3:linux:x86_64:nts": {
-      "digest": "sha256:0cf3756264ee046256f3960c905172d511152507d3d3f4147e97a02b5f5ca982",
-      "spec_hash": "sha256:0139d346f80bdd50fc856c5c70f9da208e9be9c35dca571790fe397ac79528ac"
+      "digest": "sha256:f10533ecd9f6e89a5cf807702a6b7956680e63a58bba93635046c40a10fc7f04",
+      "spec_hash": "sha256:b8cfb72951f11240b7a5c56e4b3957d9a9be745352e6385efb34308058f8b44f"
     },
     "ext:pcov:1.0.12:8.4:linux:x86_64:nts": {
-      "digest": "sha256:a9b8123041833085a007c36a5f9cd6f822da43dad4b9e234bb7be84d3c4cd9a5",
-      "spec_hash": "sha256:88bf4921e31c27c8f01606cea0a4d227b1d7168fc102c89103dc6b9d716a8ae2"
+      "digest": "sha256:6be620982ad39201a46992b3d4c4117ac54f2d006f4f483d4abe0ceecc5bf8eb",
+      "spec_hash": "sha256:7681535a3c02e2920483a6b12a062204cfc2ca7134a2a4d6623dcfa499c0812a"
     },
     "ext:pcov:1.0.12:8.5:linux:x86_64:nts": {
-      "digest": "sha256:f4158e765d47b7f5aa24cd9f05b3931212d5bffe4ce80b3c03ab97cf9e516743",
-      "spec_hash": "sha256:64451121cd7cfd189a8ef977aa3e5b22d8a1cec6f209706a7c86bfa2fbf40d0d"
+      "digest": "sha256:2512a5086f32ff97979fc7500717f129b41e4cc87e5fce779825404fc954377f",
+      "spec_hash": "sha256:853821cd111cf99c36d2d58c82dbb15c8a180897763938ce3b7d22cfd66e209f"
+    },
+    "ext:redis:6.2.0:8.2:linux:x86_64:nts": {
+      "digest": "sha256:ad4eb052460cb1df723a144dba056cd8b7ad635308ab669989e62d77026d3e8a",
+      "spec_hash": "sha256:f56e119e176dcb0a885f9daeea4abbb5fce3ec358ad50576386624009f1258c0"
     },
     "ext:redis:6.2.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:74a09faabf40546dcc6cf00b663204a9243b9f02803e8d70c8b22779ff2a599d",
-      "spec_hash": "sha256:e1a198c29bb4888710776b4a794f52464741b1d48534f7956391f71a064e0a02"
+      "digest": "sha256:58cd3eb3730f93fb974b98cf827a1775b07a7f7edc9b0ba6d77683ed81e87d1e",
+      "spec_hash": "sha256:ac1a74cc88cf94f5d90a9649b09c05c2cce00a629f5c68799af091b84d0dde32"
     },
     "ext:redis:6.2.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:f6f9c505107f04c59e6ab2693be56a7b02eb9dcae7ea7946720f4d2308ec5575",
-      "spec_hash": "sha256:cec230943f1785678a83ea25f3079f429328a34b5afd41c64b6c5333f8be472c"
+      "digest": "sha256:321795c3e9a2c945d6b0766b580772a2a03212f27312ac456921fe1990dccfbb",
+      "spec_hash": "sha256:4097c7fad8180c0d040006f5a8b477fa5d523dfe54acca89b82d2d14f665da56"
+    },
+    "ext:xdebug:3.5.1:8.2:linux:x86_64:nts": {
+      "digest": "sha256:820841c3558afbfb52005237de1338fd6dcea947046c08462e2fe94496bd5540",
+      "spec_hash": "sha256:a8cbabb86e980b7e005b21aff4fc7098084a75c3d29d38465fb7e8be78242891"
     },
     "ext:xdebug:3.5.1:8.3:linux:x86_64:nts": {
-      "digest": "sha256:7084e84d62c73a3db6afbfb7a307c3862f18e8d804f613869568fef83fdebfdd",
-      "spec_hash": "sha256:ffbbcab75e3bc74274c3c45eef5aef57d46e5809be1647b1e3d67f9a6000eb33"
+      "digest": "sha256:9a00742440f18602337c066f53e15d801b2e11e18e5f3dd6ad26af78a741cbc1",
+      "spec_hash": "sha256:3605dbb1721e8a0b6547464b7898369ef68965093c555b5bede7d46b11176626"
     },
     "ext:xdebug:3.5.1:8.4:linux:x86_64:nts": {
-      "digest": "sha256:816df23201508c4c1f04b3c8abd500879b445a6e2a625838c7b9647a02c6293a",
-      "spec_hash": "sha256:7c5e21e6648e697421c356c64f9240dc92a0eac4088002cda1decd4fccb4be66"
+      "digest": "sha256:cdd3956ce80128dbe7f67ecbb99240147088f2295d9795d48ff3fc4cac5bff53",
+      "spec_hash": "sha256:324dd1ffa734b9dcdaaf15700de1fb281f7df0c15c6daab0e47328527e4eed4f"
     },
     "ext:xdebug:3.5.1:8.5:linux:x86_64:nts": {
-      "digest": "sha256:78a3ddbbb95127240984520dc5312ad492f26f6c6028f6d61ac2fa8a526ed7a0",
-      "spec_hash": "sha256:194ce22d0728195968061234acc8612abd5a0680289d259d0fd5fa0a0b513a70"
+      "digest": "sha256:b5d8f0ca1e142bcd5006498eb978b80098671a5dd3ca16ef461cdac48b01bada",
+      "spec_hash": "sha256:9512dbb214e315821347964f370aa6f7e352ea54586ed0b9ed8ade902f5075c2"
+    },
+    "php:8.2:linux:x86_64:nts": {
+      "digest": "sha256:47e572abe189ae9ffec9c8dd304e653dcd590aa0941596d98f20976f37db3dfa",
+      "spec_hash": "sha256:926981c0300721f98728e28dce565dc3e5a7bbab3c2d9b7564b26b9071c5e2af"
     },
     "php:8.3:linux:x86_64:nts": {
       "digest": "sha256:3d2bc0d3c1b0cf2a0796d63650f6ea01fe8aff8a138e1d7bdaa99ec91ab03e59",

--- a/catalog/extensions/apcu.yaml
+++ b/catalog/extensions/apcu.yaml
@@ -5,7 +5,7 @@ source:
 versions:
   - "5.1.28"
 abi_matrix:
-  php: ["8.3", "8.4", "8.5"]
+  php: ["8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
   arch: ["x86_64"]
   ts: ["nts"]

--- a/catalog/extensions/pcov.yaml
+++ b/catalog/extensions/pcov.yaml
@@ -5,7 +5,7 @@ source:
 versions:
   - "1.0.12"
 abi_matrix:
-  php: ["8.3", "8.4", "8.5"]
+  php: ["8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
   arch: ["x86_64"]
   ts: ["nts"]

--- a/catalog/extensions/redis.yaml
+++ b/catalog/extensions/redis.yaml
@@ -5,7 +5,7 @@ source:
 versions:
   - "6.2.0"
 abi_matrix:
-  php: ["8.3", "8.4", "8.5"]
+  php: ["8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
   arch: ["x86_64"]
   ts: ["nts"]

--- a/catalog/extensions/xdebug.yaml
+++ b/catalog/extensions/xdebug.yaml
@@ -5,7 +5,7 @@ source:
 versions:
   - "3.5.1"
 abi_matrix:
-  php: ["8.3", "8.4", "8.5"]
+  php: ["8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
   arch: ["x86_64"]
   ts: ["nts"]

--- a/catalog/php.yaml
+++ b/catalog/php.yaml
@@ -81,6 +81,47 @@ versions:
       - tokenizer
       - opcache
       - zlib
+    sources:
+      url: "https://www.php.net/distributions/php-{version}.tar.xz"
+      sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
+    abi_matrix:
+      os: ["linux"]
+      arch: ["x86_64"]
+      ts: ["nts"]
+    configure_flags:
+      common: >-
+        --enable-mbstring
+        --with-curl
+        --with-zlib
+        --with-openssl
+        --enable-bcmath
+        --enable-calendar
+        --enable-exif
+        --enable-ftp
+        --enable-intl
+        --with-zip
+        --enable-soap
+        --enable-sockets
+        --with-pdo-mysql
+        --with-pdo-sqlite
+        --with-sqlite3
+        --with-readline
+        --with-sodium
+        --enable-gd
+        --with-freetype
+        --with-jpeg
+        --with-webp
+        --with-ffi
+        --with-gettext
+        --enable-pcntl
+        --enable-posix
+        --enable-shmop
+        --enable-sysvmsg
+        --enable-sysvsem
+        --enable-sysvshm
+      linux: >-
+        --with-pdo-pgsql
+        --with-pgsql
   "8.3":
     bundled_extensions:
       - calendar

--- a/test/compat/fixtures.yaml
+++ b/test/compat/fixtures.yaml
@@ -153,3 +153,52 @@ fixtures:
     extensions: 'redis'
     ini-values: ''
     coverage: 'none'
+
+  - name: bare-82
+    php-version: '8.2'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: coverage-pcov-82
+    php-version: '8.2'
+    extensions: ''
+    ini-values: ''
+    coverage: 'pcov'
+
+  - name: exclusion-82
+    php-version: '8.2'
+    extensions: ':opcache'
+    ini-values: ''
+    coverage: 'none'
+
+  - name: ini-and-coverage-82
+    php-version: '8.2'
+    extensions: ''
+    ini-values: 'memory_limit=256M,date.timezone=UTC'
+    coverage: 'xdebug'
+
+  - name: ini-file-development-82
+    php-version: '8.2'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+    ini-file: 'development'
+
+  - name: multi-ext-82
+    php-version: '8.2'
+    extensions: 'redis, xdebug'
+    ini-values: ''
+    coverage: 'none'
+
+  - name: none-reset-82
+    php-version: '8.2'
+    extensions: 'none, redis'
+    ini-values: ''
+    coverage: 'none'
+
+  - name: single-ext-82
+    php-version: '8.2'
+    extensions: 'redis'
+    ini-values: ''
+    coverage: 'none'


### PR DESCRIPTION
## Summary

PR-3 of the Phase-2 version-expansion slice. Same template as PR-1 (#37) / PR-2 (#39) with `8.2`.

- Flips on `sources`/`abi_matrix`/`configure_flags` for PHP 8.2 in `catalog/php.yaml` (byte-copy of the 8.4 block per spec §4.2-A).
- Extends `abi_matrix.php` on redis/xdebug/pcov/apcu to include `"8.2"`.
- Adds 8 new compat-harness fixtures mirroring the 8.4 set, suffixed `-82`.

## Extension ABI audit (PHP 8.2)

| Extension | 8.2 support | Source |
|---|---|---|
| redis 6.2.0 | ✓ | PECL `package.xml`: `<min>7.4.0</min>`, no `<max>` |
| xdebug 3.5.1 | ✓ | PECL `package.xml`: `<min>8.0.0</min>`, `<max>8.5.99</max>` |
| pcov 1.0.12 | ✓ | PECL `package.xml`: `<min>7.1.0</min>`, no `<max>` |
| apcu 5.1.28 | ✓ | PECL `package.xml`: `<min>7.0.0-dev</min>`, no `<max>` |

No excludes needed.

## Test plan

- [ ] CI: planner emits 1 × 8.2 core cell + 4 × 8.2 ext cells + spec_hash-refresh cells.
- [ ] CI: harness passes all 32 fixture pairs (8 × 4 versions).
- [ ] CI: `make check` passes.

Spec: `docs/superpowers/specs/2026-04-21-phase2-version-expansion-design.md`