### PR TITLE
feat(workflows): descriptive build-extension / build-php-core job names

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -35,6 +35,7 @@ on:
 
 jobs:
   build:
+    name: 'ext ${{ inputs.extension }} ${{ inputs.ext_version }} @ PHP ${{ inputs.php_abi }}'
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/.github/workflows/build-php-core.yml
+++ b/.github/workflows/build-php-core.yml
@@ -32,6 +32,7 @@ on:
 
 jobs:
   build:
+    name: 'core PHP ${{ inputs.version }} (${{ inputs.os }}/${{ inputs.arch }}/${{ inputs.ts }})'
     runs-on: ubuntu-24.04
     permissions:
       packages: write


### PR DESCRIPTION
## Problem

GitHub Actions' run sidebar flattens reusable-workflow job labels to the callee's `jobs.<key>:` when no explicit `name:` is set. `build-extension.yml` and `build-php-core.yml` both use the key `build`, so every cell in a 30+ fan-out matrix rendered identically as "build" — impossible to tell which extension × PHP version a given cell was running.

## Fix

Add interpolated `name:` to the callee job in each reusable workflow:

- `build-extension.yml` → `ext <name> <version> @ PHP <php_abi>`
- `build-php-core.yml`  → `core PHP <version> (<os>/<arch>/<ts>)`

Other workflows that have a `build` job key (`compat-harness.yml`, `integration-test.yml`) already set `name: Build phpup`; they already render correctly and need no change.

## Diff

```diff
+    name: 'ext ${{ inputs.extension }} ${{ inputs.ext_version }} @ PHP ${{ inputs.php_abi }}'
```

```diff
+    name: 'core PHP ${{ inputs.version }} (${{ inputs.os }}/${{ inputs.arch }}/${{ inputs.ts }})'
```

## Test plan

- [ ] CI: `ci-lint` passes (prettier already validated locally).
- [ ] On the next matrix-fan-out run (next catalog/builder PR), the sidebar shows `ext redis 6.2.0 @ PHP 8.4-nts` etc. instead of `build`.

No impact on bundles, no impact on required gates, no compat-matrix implication.