### PR TITLE
feat: aarch64 infrastructure + PHP cores (phase 2 C1)

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   build:
     name: 'ext ${{ inputs.extension }} ${{ inputs.ext_version }} @ PHP ${{ inputs.php_abi }}'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       packages: write
       id-token: write

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -46,9 +46,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install oras
+        env:
+          ORAS_ARCH: ${{ inputs.arch == 'aarch64' && 'arm64' || 'amd64' }}
         run: |
-          curl -sSfLO "https://github.com/oras-project/oras/releases/download/v1.3.1/oras_1.3.1_linux_amd64.tar.gz"
-          tar -xzf oras_1.3.1_linux_amd64.tar.gz -C /usr/local/bin oras
+          curl -sSfLO "https://github.com/oras-project/oras/releases/download/v1.3.1/oras_1.3.1_linux_${ORAS_ARCH}.tar.gz"
+          tar -xzf "oras_1.3.1_linux_${ORAS_ARCH}.tar.gz" -C /usr/local/bin oras
 
       - name: Resolve build_deps from catalog
         id: build_deps

--- a/.github/workflows/build-php-core.yml
+++ b/.github/workflows/build-php-core.yml
@@ -43,9 +43,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install oras
+        env:
+          ORAS_ARCH: ${{ inputs.arch == 'aarch64' && 'arm64' || 'amd64' }}
         run: |
-          curl -sSfLO "https://github.com/oras-project/oras/releases/download/v1.3.1/oras_1.3.1_linux_amd64.tar.gz"
-          tar -xzf oras_1.3.1_linux_amd64.tar.gz -C /usr/local/bin oras
+          curl -sSfLO "https://github.com/oras-project/oras/releases/download/v1.3.1/oras_1.3.1_linux_${ORAS_ARCH}.tar.gz"
+          tar -xzf "oras_1.3.1_linux_${ORAS_ARCH}.tar.gz" -C /usr/local/bin oras
 
       - name: Build PHP
         env:

--- a/.github/workflows/build-php-core.yml
+++ b/.github/workflows/build-php-core.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   build:
     name: 'core PHP ${{ inputs.version }} (${{ inputs.os }}/${{ inputs.arch }}/${{ inputs.ts }})'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       packages: write
       id-token: write

--- a/.github/workflows/compat-harness.yml
+++ b/.github/workflows/compat-harness.yml
@@ -16,8 +16,12 @@ permissions:
 
 jobs:
   build:
-    name: Build phpup
+    name: 'Build phpup (${{ matrix.goarch }})'
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -26,11 +30,11 @@ jobs:
       - name: Build binary
         run: |
           cp bundles.lock cmd/phpup/bundles.lock
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o phpup ./cmd/phpup
+          GOOS=linux GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build -o phpup ./cmd/phpup
           rm -f cmd/phpup/bundles.lock
       - uses: actions/upload-artifact@v7
         with:
-          name: phpup
+          name: phpup-${{ matrix.goarch }}
           path: phpup
           retention-days: 1
 
@@ -70,7 +74,7 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: phpup
+          name: phpup-${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }}
 
       - name: Place binary in tool cache
         run: |

--- a/.github/workflows/compat-harness.yml
+++ b/.github/workflows/compat-harness.yml
@@ -46,16 +46,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: load
-        # Filter fixtures by PHP versions present in bundles.lock so a fixture
-        # referencing a not-yet-built PHP version doesn't fail fast against an
-        # unresolvable lockfile entry. Plan-and-build's harness call (after
-        # update-lock) reads the freshly-committed lockfile and picks up the
-        # full set; the standalone harness invocation here only runs fixtures
-        # whose PHP version is already buildable on the current ref.
+        # Filter fixtures by (PHP version, arch) pairs present in bundles.lock
+        # so a fixture referencing a not-yet-built combination (new PHP version
+        # OR new arch) doesn't fail fast against an unresolvable lockfile entry.
+        # Plan-and-build's harness call (after update-lock) reads the
+        # freshly-committed lockfile and picks up the full set; the standalone
+        # harness here only runs fixtures whose (version, arch) is already
+        # buildable on the current ref.
+        #
+        # Fixtures default arch to 'x86_64' when the field is absent so existing
+        # 50 x86_64 fixtures stay covered without schema churn.
         run: |
-          versions_json=$(jq -c '[.bundles | keys[] | select(startswith("php:")) | split(":")[1]] | unique' bundles.lock)
+          pairs_json=$(jq -c '[.bundles | keys[] | select(startswith("php:")) | capture("^php:(?<v>[^:]+):linux:(?<a>[^:]+):") | .v + "/" + .a] | unique' bundles.lock)
           matrix=$(yq -o=json '.fixtures' test/compat/fixtures.yaml \
-            | jq --argjson v "$versions_json" -c '{include: [.[] | select(.["php-version"] as $pv | $v | index($pv))]}')
+            | jq --argjson p "$pairs_json" -c '{include: [.[] | select((.["php-version"] + "/" + (.arch // "x86_64")) as $pa | $p | index($pa))]}')
           {
             echo "matrix<<EOF"
             echo "$matrix"

--- a/.github/workflows/compat-harness.yml
+++ b/.github/workflows/compat-harness.yml
@@ -61,7 +61,7 @@ jobs:
   ours:
     name: 'ours: ${{ matrix.name }}'
     needs: [build, fixtures]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.fixtures.outputs.matrix) }}
@@ -110,7 +110,7 @@ jobs:
   theirs:
     name: 'theirs: ${{ matrix.name }}'
     needs: [fixtures]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.fixtures.outputs.matrix) }}

--- a/builders/linux/build-ext.sh
+++ b/builders/linux/build-ext.sh
@@ -10,6 +10,7 @@ EXT_VERSION="${EXT_VERSION:?EXT_VERSION is required}"
 PHP_ABI="${PHP_ABI:?PHP_ABI is required}"
 OUTPUT_DIR="${OUTPUT_DIR:-/tmp/ext-out}"
 WORKSPACE="${WORKSPACE:-$(pwd)}"
+ARCH="${ARCH:-x86_64}"
 
 echo "Building extension ${EXT_NAME} ${EXT_VERSION} for PHP ${PHP_ABI}"
 
@@ -34,7 +35,7 @@ fi
 PHP_TS=$(echo "$PHP_ABI" | rev | cut -d- -f1 | rev)
 PHP_VER=$(echo "$PHP_ABI" | rev | cut -d- -f2- | rev)
 echo "Fetching PHP core for ABI ${PHP_ABI}"
-"${WORKSPACE}/builders/common/fetch-core.sh" "$PHP_ABI" linux x86_64
+"${WORKSPACE}/builders/common/fetch-core.sh" "$PHP_ABI" linux "$ARCH"
 
 # Symlink so that phpize/php-config resolve their compiled prefix correctly.
 # PHP was built with --prefix=/usr/local but extracted to /opt/buildrush/core/usr/local.

--- a/bundles.lock
+++ b/bundles.lock
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-04-21T17:20:59.713505876Z",
+  "generated_at": "2026-04-21T17:22:57.807474034Z",
   "bundles": {
     "ext:amqp:2.2.0:8.1:linux:x86_64:nts": {
       "digest": "sha256:ba4c4c4f988737edd081e0a48c30c784b79894a83282e54f04dcb40d8d68db8c",
@@ -63,19 +63,19 @@
       "spec_hash": "sha256:edcd7f6b5e22bbb80d573f6d1eabb79d27a850f5c36ef5c34c12a357506c411a"
     },
     "ext:grpc:1.80.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:09604e1602569100d5a3fb311e688b2df4895997f426a96410e4e7a969268e74",
+      "digest": "sha256:83e6bff82abd4b34a8f6cc0f5faf131cf7dc3807d5da9014ae63dc8ee86d39dd",
       "spec_hash": "sha256:358cdb435b16604b11587af859ffa2acb61e987087bf85376a64a08ed06b0d6d"
     },
     "ext:grpc:1.80.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:c24d377e6ec3bcc4e62e6109e0b633a1ff013735f5775f55f79cc306c938cb52",
+      "digest": "sha256:d0d0ee936556ebb3e9f14eb5f91ec83fb7a8f433ff36cddfcb6665939248c694",
       "spec_hash": "sha256:4d69585628ff8bc82f19f6898768120027dc751c9463c2122ce979e539d039fd"
     },
     "ext:grpc:1.80.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:4e928ff882bc7530375b7a6e99d89e81a5d7a7adf280984a42ed9352bcbc8fd4",
+      "digest": "sha256:da905d841a0e8571b6090c5024fcd1275e0956faebc8efa0e107be590b5ce770",
       "spec_hash": "sha256:f4fde1b57eae785fe6d439888d08213e54ef8c34a62b6abfbf5dec62b013408a"
     },
     "ext:grpc:1.80.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:18303616813df53faea426dd9b7d10611eafc4dd13e400efef3594fbc2b06188",
+      "digest": "sha256:071affd8b84fdd5565a6bc2674a3e61d483f0aa5cb65b1cbe851aa8be7629060",
       "spec_hash": "sha256:b7d58b750b0db77e0b2c394c9c9998b6422d01f3fec60911758822f015164aa8"
     },
     "ext:grpc:1.80.0:8.5:linux:x86_64:nts": {

--- a/bundles.lock
+++ b/bundles.lock
@@ -1,370 +1,390 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-04-21T16:15:41.933795546Z",
+  "generated_at": "2026-04-21T17:20:59.713505876Z",
   "bundles": {
     "ext:amqp:2.2.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:3369f1cb2a0ad4d29d822dcecc81eff12136b270850b2fc93758f8ff082ec0f7",
-      "spec_hash": "sha256:f7ae4ec8f03606723ecd7927021eed1f061e6f99011dc9f6ee4a933b6b0232a1"
+      "digest": "sha256:ba4c4c4f988737edd081e0a48c30c784b79894a83282e54f04dcb40d8d68db8c",
+      "spec_hash": "sha256:30c227a6566b4f6f967fbcc497e446bd898198f6a925e3d5bbcd0e4397907d88"
     },
     "ext:amqp:2.2.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:e7509055114c2b098bf67351e0c1493e9ca330ad0b3bda220fcf6e8dcbd573ed",
-      "spec_hash": "sha256:50b8cf9fb3fa3ab2a1a40788c535391f4cc28e830c94a23cc350fb9e448ef706"
+      "digest": "sha256:3f048d25999e1a4d394c4a4d2230c8dc85b609ee3d3e112541fbf1dd1b6bc47b",
+      "spec_hash": "sha256:3cac0a34ed06af1812da25dcc0279d9b9a0a324f89e2ecb9fc7ecc3a3afc3d62"
     },
     "ext:amqp:2.2.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:d1ec089a874fa8a67e91553a293725ec73f445d5d0f09ad87524955cc1da453e",
-      "spec_hash": "sha256:05527bb2cd06a1d2848b92afdbb818e0297b4c6ef82a51226a4824546f85ad0f"
+      "digest": "sha256:aecaaccf96c4c8a9e5f1f51d49fab3e35a0ef1bcf04926801aef7629eceb5076",
+      "spec_hash": "sha256:618cef2b3118100f1c36fd4c33c0712fa17083857dad1378241de6bb35695994"
     },
     "ext:amqp:2.2.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:486ea96925c39480f03593962520301d819b6df1c2f7bcdecfb57c55d7cce3aa",
-      "spec_hash": "sha256:e0931befb9dfc18a14d2d239a5758190a87d76f18b8233e8b626eb764ead3890"
+      "digest": "sha256:2d1198f542a3c3add94985923aa726a851b48fce28fcf0988a04d97018447687",
+      "spec_hash": "sha256:527dcd9e2536373468e5bc6b011510cc68d189266cfe7fae5966473c47c85657"
     },
     "ext:amqp:2.2.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:3797895c294b656b60942e4d15328ab3420d51c56134a016b6ed0c75257433e4",
-      "spec_hash": "sha256:0a23f784a2c85bcf8292460e0c6fd09620a621b37d757f841d281168fc4380fb"
+      "digest": "sha256:620c4c6484132c770da39962b365d9b9768e027e02f8a78848ca75664477d7d3",
+      "spec_hash": "sha256:9765f407ac6b0b355a691864477cc6bbfae488c53dad54c1f3ec45bc58621c0c"
     },
     "ext:apcu:5.1.28:8.1:linux:x86_64:nts": {
-      "digest": "sha256:be757d56baed426429c955807a5896aa0ad9ebaabf16e8131d1acba6896b9f63",
-      "spec_hash": "sha256:bdba2c633fe4a0199fce524279cf8f2f34309858790e28abbca4d0afdd200ba1"
+      "digest": "sha256:67ea427f6bbdbd90833bf65257319e03dd26835670d3a70a8619c1782fea9728",
+      "spec_hash": "sha256:868f7a999cc3423bfe56945444e28e5bd4f37dc60970bc3f378f19a836a2ae49"
     },
     "ext:apcu:5.1.28:8.2:linux:x86_64:nts": {
-      "digest": "sha256:5a4cdf67c919bdfeb47437bd9913c02518d0272b0731319898fc83d67653d908",
-      "spec_hash": "sha256:371303da35031a0814e990df317b1334b70daa3e6afe83896f13b82208aa954f"
+      "digest": "sha256:d6105f30f18e774c14f91fe5e7fc7089682fb63f959fbb093f8f0be7e1740172",
+      "spec_hash": "sha256:6a02708499d7ab18a47afb6c010bacf728a3219cb4a37be74822176e754a8058"
     },
     "ext:apcu:5.1.28:8.3:linux:x86_64:nts": {
-      "digest": "sha256:3569efb70afe465a6b167e995bacf40ace485604dd5dc05236c0df60ff9c4a09",
-      "spec_hash": "sha256:88eae9fdac9969b537381c3052c230cfe415338459b5ff883384f6fc304b9cfe"
+      "digest": "sha256:a2ab963bef56076d197b61bc0d4626417e4f24233d3729a8e1d3cb47ff030c5e",
+      "spec_hash": "sha256:92bf73b0f5764d798fd0257d5d94794e44319a8962c7bad05dc7ae8559e4d484"
     },
     "ext:apcu:5.1.28:8.4:linux:x86_64:nts": {
-      "digest": "sha256:6ff9ee57931f2427a057a93eb0c8e3e10e43c6e972d16ce5a85eed575661328f",
-      "spec_hash": "sha256:707c7c0acd04b728c0c62c765f1d3e4f90bc10400fc318b517969cb4376c8a20"
+      "digest": "sha256:c9f8e34884e1ff61f064ebf497ecfab4903661678a32e537513fd0dac2d5401d",
+      "spec_hash": "sha256:767a3b0e2284c1966f768bed27a631432eda8c29ee6b3939c677c7d4c1705b8f"
     },
     "ext:apcu:5.1.28:8.5:linux:x86_64:nts": {
-      "digest": "sha256:16319354c5d1e3389fcbba3db7f1e1da59d92ed956540b440f749114586a9a80",
-      "spec_hash": "sha256:2696825c12e619149807df4239bb0e167e477c8c13bc259a51aeb224945426f7"
+      "digest": "sha256:733dbaa5b8dc5c1feadf8ef521bd676e2c40ea7887cd4f531dc32e59cb615e26",
+      "spec_hash": "sha256:0c198a89e676cdaa721801a9b33216a0fbcbb91d900136e157e4af61e6f671bd"
     },
     "ext:event:3.1.4:8.1:linux:x86_64:nts": {
-      "digest": "sha256:54f2f24dfb87ae409427d87d5e550a3b5682e078327c84491f317161058cb755",
-      "spec_hash": "sha256:a2a10ebf6cc31c58f0ec405a0d6fdb810d307ab996470d516e5cb0dd3880b0bf"
+      "digest": "sha256:ed276ff5cb9a524abc051457d57c22b62d370011fc7d19faddb7b93e26773fec",
+      "spec_hash": "sha256:e97da991cbe6ddd4fc7097bbea204512c53163298703befb685b82d124f3ac47"
     },
     "ext:event:3.1.4:8.2:linux:x86_64:nts": {
-      "digest": "sha256:18baab12d90007cce8e4d58cca2e51d82e3aa4140782bef40cf386dc37d7378d",
-      "spec_hash": "sha256:2b5609648d9ada31a6ecf85cb3895b97f2f4d2dc1e84e401e834d54c6a54bd14"
+      "digest": "sha256:e9482ec7a065255b70e30312506f5f735dbd0c1b8e7aa4edb198db8c5a4630a3",
+      "spec_hash": "sha256:eb1ad5185fe7a290c001e8c8a815782c758fc29db48b0c6ed1d40ec4aa961a5c"
     },
     "ext:event:3.1.4:8.3:linux:x86_64:nts": {
-      "digest": "sha256:1e0a3abae55b410ffd369675b66fbd53d9dff5488b5af74f290b99021df4a420",
-      "spec_hash": "sha256:3d8ce4f02ab46617bf3af144a7e8e4ed1d76453a4340cb14587aa55325cd0aea"
+      "digest": "sha256:3014f3364c870c495503f12a4f57914432f3e16c52c1ce507b5de739a4f8b609",
+      "spec_hash": "sha256:dc99e4148dfb99e1133a4e341fbaab948671cb08788b3fa9d74b78e72b1f1765"
     },
     "ext:event:3.1.4:8.4:linux:x86_64:nts": {
-      "digest": "sha256:be33c03a70e9c0b791e78b193328aaa5dccae58efb3e5a17f3eefc0de99c1106",
-      "spec_hash": "sha256:86dd0e72afe0a0974a833bd9552088b60725d84d48c0a02900c0acdb8a61d873"
+      "digest": "sha256:9052d18faf6315b9c4c1272e01526034658acca5ea67e656a8643bf8396f46bc",
+      "spec_hash": "sha256:cf3c1d3c80d1254ada997f5ac6782930a84cf164a254436b293ddccc87075f64"
     },
     "ext:event:3.1.4:8.5:linux:x86_64:nts": {
-      "digest": "sha256:fba06ed4e426b0b7f498b7b1fe2a55df8882f75abab7839920300a38c0cd7714",
-      "spec_hash": "sha256:bb09a7ac3024ad3975c5261167c705ff03475dc8276cc335037946123afd69ec"
+      "digest": "sha256:18508879860d7a04a60b361e5253783af88838ce6f00fde93941938c88c9f08f",
+      "spec_hash": "sha256:edcd7f6b5e22bbb80d573f6d1eabb79d27a850f5c36ef5c34c12a357506c411a"
     },
     "ext:grpc:1.80.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:7347c4b80bb4fba8590d38fdbfcb1fb02a2cf4422f1376bce69c7e4d405c47b6",
-      "spec_hash": "sha256:46fa86c7702e85f657c67dbe783d37805444d7d5fb525b9c2fef8834287ef3a9"
+      "digest": "sha256:09604e1602569100d5a3fb311e688b2df4895997f426a96410e4e7a969268e74",
+      "spec_hash": "sha256:358cdb435b16604b11587af859ffa2acb61e987087bf85376a64a08ed06b0d6d"
     },
     "ext:grpc:1.80.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:0400886f24585883cae659f0bb53cb1017c25e6f5a63abc9be27a94b9c57456e",
-      "spec_hash": "sha256:f1848589ab585a950dcfdc09e776c964d146c3d9862a7429958ae8c7afdc912b"
+      "digest": "sha256:c24d377e6ec3bcc4e62e6109e0b633a1ff013735f5775f55f79cc306c938cb52",
+      "spec_hash": "sha256:4d69585628ff8bc82f19f6898768120027dc751c9463c2122ce979e539d039fd"
     },
     "ext:grpc:1.80.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:e38e1fb7d68785cc7fc15748444802b7f33a05ed9c4d2a9ce0afc8686186c1f0",
-      "spec_hash": "sha256:8ee8014ffeb6f2912af694c529b508b17c38706eae6381f0f81aca80b3dd5282"
+      "digest": "sha256:4e928ff882bc7530375b7a6e99d89e81a5d7a7adf280984a42ed9352bcbc8fd4",
+      "spec_hash": "sha256:f4fde1b57eae785fe6d439888d08213e54ef8c34a62b6abfbf5dec62b013408a"
     },
     "ext:grpc:1.80.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:a98dfba2cc460e8c9dd25e70b10399a96a5237442d7eda054ae673031681e259",
-      "spec_hash": "sha256:456da9a3cde4e487f4e59314caea91ef16c1683e5ad4826fe4b634fcbf9b90ad"
+      "digest": "sha256:18303616813df53faea426dd9b7d10611eafc4dd13e400efef3594fbc2b06188",
+      "spec_hash": "sha256:b7d58b750b0db77e0b2c394c9c9998b6422d01f3fec60911758822f015164aa8"
     },
     "ext:grpc:1.80.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:d9223c49019911dafe372e06e31ccb15079abc727c251bdaf99223da23b0aca0",
-      "spec_hash": "sha256:d116b6722dfe508842fe49b300f077e40699093a99bc787dce61fe44697af742"
+      "digest": "sha256:9bc85c5b6813980c768e58f07169c89ea2619dea860de9f8978af0adbdf875f0",
+      "spec_hash": "sha256:39a3254b816b883e194a051ac9c97a1a947be871dcba5a1d5386e0aec2f408c2"
     },
     "ext:igbinary:3.2.16:8.1:linux:x86_64:nts": {
-      "digest": "sha256:355fbeae28c92b5c2306ba9b819d3b8d8f3d9e0a5dddf7bb594a43c862d44ffa",
-      "spec_hash": "sha256:f256c69316a02bce8427734ae3e1056cc53f38b56a9cd635578dc29c5c33c4c2"
+      "digest": "sha256:51dbabc9159a24f7a19a2d57981ffb260a5c2275c9efe34bf8d7af7c995aa22e",
+      "spec_hash": "sha256:728f7f355d0c1bdb522831e09887fbb4b2aca089300636703b52598ce0a76791"
     },
     "ext:igbinary:3.2.16:8.2:linux:x86_64:nts": {
-      "digest": "sha256:9fb40b7ecb2ee0ccf129c5adf4092b21f546efc77da075b0c858b7628e51c879",
-      "spec_hash": "sha256:9f8db96672bd0a2e366957d338755e829ce1366a773b69841ae05a03c23051e0"
+      "digest": "sha256:9b4163a93a49ce9a17a0e793b1eec98b03f03c6fe0f8e9549c340513238fbe3c",
+      "spec_hash": "sha256:0ed654b215873f269e07c24ef64808aa59df2e13af23fd329a5db6b9754952d8"
     },
     "ext:igbinary:3.2.16:8.3:linux:x86_64:nts": {
-      "digest": "sha256:8347283398e6913aa9bdccfa4756aaf5f6c7752766cc03be929050598d0d3fe0",
-      "spec_hash": "sha256:973f5d27f6631249e508e35cc58e749ab8665fd07a94b62cb19b0063bc34be43"
+      "digest": "sha256:9a3be3986dd8e3bb463a7cfd71abb16252428f455143c8e0562aad3378674f49",
+      "spec_hash": "sha256:18fbb0b2abcd7e4e0d81d780d9a819b9cc7f3e04a6e84253c698c1a9f40eac23"
     },
     "ext:igbinary:3.2.16:8.4:linux:x86_64:nts": {
-      "digest": "sha256:6630dc4c26decfe362223f423a50ba4378c81406e58908f8212aaeadd069c22b",
-      "spec_hash": "sha256:777bbb09e59bb89faeb78d4354b33d6e87c3aeaf52557e8598ab681b3ea3bd1f"
+      "digest": "sha256:309b514a14b942c72c3ebd43ac6b96579701ac546ff32787c6315f6fff30fb8b",
+      "spec_hash": "sha256:ce13f83111e59ee963579664ae4270b0dbdec8b35501a19af2cec507a5596424"
     },
     "ext:imagick:3.8.1:8.1:linux:x86_64:nts": {
-      "digest": "sha256:f8b9c5e3ec55b3f9e14ce72377828c70016b3731668ff8545a01e329c5fee7ad",
-      "spec_hash": "sha256:60085ff8d67760e988abb4bff2f74d73fffb2ffc63aa8c1a9e74c6039239a8c3"
+      "digest": "sha256:ea38456897fe2a1f8b1252c46f3416597574d41dbd34b69f7b0b57172dbbd11b",
+      "spec_hash": "sha256:1cdbcd0e70f2bcb76235d320e747a9f61f14b43e357ccc6a734a8d697addc347"
     },
     "ext:imagick:3.8.1:8.2:linux:x86_64:nts": {
-      "digest": "sha256:5fed96af8e99e2aaec5a223b01129356eb6de5e32396ac5c4a88b4b57502c66c",
-      "spec_hash": "sha256:a3659d1f1b0dcd8f016ca0de924f3c46e9259077beab1e173b4e79c91c33b2b5"
+      "digest": "sha256:3ad7714bb60ad36cd3c12c4d38c396a4ce11b2d6219bd004e3f60e453294dd70",
+      "spec_hash": "sha256:34c964c24fb26d57577cd153305adaece759cf1b7fe853783e53e6e96be1e7c1"
     },
     "ext:imagick:3.8.1:8.3:linux:x86_64:nts": {
-      "digest": "sha256:74a84176fd4bfa0d64288024f4b8cb71f4dfd1e1d2c20500fa0a32023c719558",
-      "spec_hash": "sha256:1499e6c7f2efe7981e6f7d4490c64a957ab9c2de57de4d71c882255d0767910f"
+      "digest": "sha256:b318ac46672c0a6a821c7fcd8974d2f1eb6eb1961571d894eb979025dc0ab6d6",
+      "spec_hash": "sha256:d4c01545267d6e0955aef8ad607cde8e84d9e3b9bde3d6e2601d65a4582b97e9"
     },
     "ext:imagick:3.8.1:8.4:linux:x86_64:nts": {
-      "digest": "sha256:4052addaf8f9773a3c00d2c116c19b03d40e7de7df2114a79036a3cf21af1daf",
-      "spec_hash": "sha256:bef9f50590f1d5f31368d59c230984856d501b818baee4a21c37eca3142b6e25"
+      "digest": "sha256:3bb4e272a9266e356deb6bc13a420de85aa94a4547bb0e4bd41ae3fa6ae13ee1",
+      "spec_hash": "sha256:e3ec0927fe87d6fbd1310d8b8bb707b6a54bce49e741cac93299a2b29d8e3621"
     },
     "ext:imagick:3.8.1:8.5:linux:x86_64:nts": {
-      "digest": "sha256:1d19768ce493f3aaf6a20b0c23c3216238d9922796220377a19b672d992c939a",
-      "spec_hash": "sha256:fc5aaaafd1c8db34993c14059b73b541399979c4be7faa2d909e3d866a94d53d"
+      "digest": "sha256:c5fbdd5b9900bf0339af60da0f4ee544fe36765482e2ab051607efe2129513f1",
+      "spec_hash": "sha256:338e5476d7d4f9b20eaf2240fa0558b488a03951f6fbc965e0684299beb90670"
     },
     "ext:memcached:3.4.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:b335e2e08e7d31e7f4ace45acd68fece81389e775a5a222fd75ccc668fbc42a9",
-      "spec_hash": "sha256:3b5c3824c79e926a2cb1e2508aabb8f63a130a986e71b5752db2d38ec238d114"
+      "digest": "sha256:64ecf925845c4357fde80c396c1afb28d2f4510f3e3adf9f728f61c9b15808d6",
+      "spec_hash": "sha256:af1a682fd584e18513a14098603da147062864054d0c1b0760c6640e21b51759"
     },
     "ext:memcached:3.4.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:5ebf6e95545ef671ab4dc8c6cb97d56eb499ac8c48e7d2cee0476ba56e8c2096",
-      "spec_hash": "sha256:a794e989ddeb4c14e67e435dae1265f8a77e482d610c745a8555c7cf8eeafdce"
+      "digest": "sha256:d884ff4e3f4a4ff14e350403ca4b50d191a3500cb3c71bd687e8d88a45b5a39e",
+      "spec_hash": "sha256:1260d0f4fd4e5db15aff1832a75f0f395929bbfeff627ec088dbabac6a96820a"
     },
     "ext:memcached:3.4.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:0bf040a815bf103f62f631a76a9ff49f3b4e2060c366f3c0d0c652b3ceb2bedd",
-      "spec_hash": "sha256:d026b12d0287d01c0d23f3b7ab39619c16f2010f74fe57258167833335a4d8a2"
+      "digest": "sha256:67f39bd7bbb150d2c64fb2ae18032ed044f2a1e05ae6bf99bbc98bdfd612fd07",
+      "spec_hash": "sha256:a8ea84818178fac59c3c17afad91ea94403b3113ae5f1651a10dbfa58cf2513d"
     },
     "ext:memcached:3.4.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:a9d76e324082b59aa7534f1cca92676784822682df6e86d160e9b98d9bd88cd6",
-      "spec_hash": "sha256:62b22602d43b576b25c72a9d37d59a2c0d27989775bcd63e15f0354bf352706d"
+      "digest": "sha256:66539008607b5ae54ebcef0624fabc55c8e0916658176aa55d51251b466d71be",
+      "spec_hash": "sha256:e190bbdb396ed86f8b44e938553c22bdb158b3f237e0faffaae6c90f917edc9d"
     },
     "ext:memcached:3.4.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:41395f30424a0c330075be12bc5cbe970697b15d2ae35e0bd264e58954f06c9c",
-      "spec_hash": "sha256:a63d1987c9c0cd0900e6f3035744e886257a8632464e095a08f11d6b63f166de"
+      "digest": "sha256:22edf2ca18683778dd9d6c7963cd6700cc5a2ce0b348aff854d362c4dc8ab1b1",
+      "spec_hash": "sha256:cb079cc94d798f29a1006adecf4f50f9253395f7abbf426dc3aae4282ff1d4f0"
     },
     "ext:mongodb:2.2.1:8.1:linux:x86_64:nts": {
-      "digest": "sha256:53e1ef77896a9e1c1981d984619ab98a641e822a64d2b3681d2eb3e946284442",
-      "spec_hash": "sha256:4537c2df2d73aad3c48d15c5043bc87c29aeff0ae0ca1e4e2ecc086116b1370a"
+      "digest": "sha256:8803231f3c7d97c68b453ce57982daa35c031c005800481da8aa0dbb94d5ff8f",
+      "spec_hash": "sha256:26b5216c131695db62a40fca2311328dc32b39870fd9643db69291bc211d77e0"
     },
     "ext:mongodb:2.2.1:8.2:linux:x86_64:nts": {
-      "digest": "sha256:ed79aa179376ce5171f62783330693a37c2a510c3156a1f332c6cc0b28574343",
-      "spec_hash": "sha256:ddfd4d8282bdd9355ec8aa20c1a498a17a9a6cbdad8d98ce44f12646aa9933fb"
+      "digest": "sha256:86fdc12462e91bee54d9d5d6991c3e877103567ff647aa36bca0e9b3dde8d579",
+      "spec_hash": "sha256:8e3f5abd49d3cf785f5373ce9128eb36c67d6eb576308d27a704a9c06d706e53"
     },
     "ext:mongodb:2.2.1:8.3:linux:x86_64:nts": {
-      "digest": "sha256:3a28d8a483b16db0138e17e0d82a519ba8b9c39c7e6e62ca7a2c4c8ec7901cdb",
-      "spec_hash": "sha256:78ad16add4332cec65335d865c02c79bde0add34eedc6488eb3b2c860093316b"
+      "digest": "sha256:6d0517abb5378d2bf70b33b92bc1b61a7ac538f6db7e102fb936b9fa9d468e3e",
+      "spec_hash": "sha256:c68129df1c791e45ab41883a95a94e28f3293a206f339ec7dce3ad02a0646c71"
     },
     "ext:mongodb:2.2.1:8.4:linux:x86_64:nts": {
-      "digest": "sha256:5e4c23049fa18a8e2559798134ad0f211854ad48e4e9e825711d78dcf50389a7",
-      "spec_hash": "sha256:b183ac9b1af531e379403f0367522e9c673fbe754ac485e1aa94160c78826c0a"
+      "digest": "sha256:d114888f7c456c336d7c0bc228bae6ca7b222aa4d7caa34bb077994a16a317fd",
+      "spec_hash": "sha256:c052d64d8e9f9f12bea3906fea290d41c825a85cdb701481befb4ccfed0671d9"
     },
     "ext:mongodb:2.2.1:8.5:linux:x86_64:nts": {
-      "digest": "sha256:1fe70be5e1e192a3bd9eeeec933e4ff79b83bff9f76cfab0fa7816157e2e4b34",
-      "spec_hash": "sha256:8a1344f3a2faaf4ee409faff38ce9bdac8bf87ace2c75996af9a0ec83ed18843"
+      "digest": "sha256:ba4ef7b889a7730e53b7c5267cbd27ee2570408dc8a8421b249fedd061f9a6b5",
+      "spec_hash": "sha256:5c0f1f549d12023632109076d9d4a97256765662790a0e4d30387da26120a195"
     },
     "ext:msgpack:3.0.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:7d54fe45af8f5186caf56fc05088692460fd315db855b0e9b2c105dd0ef18d48",
-      "spec_hash": "sha256:2c0c3322ec48b35a9495daf11ec34bee888d785fd47b792def11f870c74fc46d"
+      "digest": "sha256:4175bd0e01cef1a3eeb37632e11d0f66ce8f30fa2ad07198669a64dca1d07437",
+      "spec_hash": "sha256:25e7f0e49cf21bf59f6b95c24dc01d6b2f2b5e36a89c8ed400b9245c3e7dd7e7"
     },
     "ext:msgpack:3.0.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:fb2891ac22c78aab3be82e68c6792c807a4ea65170ca7ea142b160d56ed05b51",
-      "spec_hash": "sha256:e0453d29335bad0b0f81a83b1b2ab8fc0e099f35e671f8d61194f38672d24e01"
+      "digest": "sha256:7ad276c1eb1a8bc5774735612d06cb1eb34bab19757dca41e280414c1f1feba8",
+      "spec_hash": "sha256:9cbc0e9519cec85834c9acb6ffd252786e079abca47edec58c4ba1e3b31e9dad"
     },
     "ext:msgpack:3.0.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:6ea7f846174158f19fa8f6b66b6856c368b085d80b3c29ed2eb4d9068b4f755e",
-      "spec_hash": "sha256:3bd5c5b9f50f9ac75d2abddda78be990478164dd343dd5c8251f187fd5d10b8b"
+      "digest": "sha256:c60d5914fe2813c77d23c5314a724d85dfbb3e89fee9145a2d65c3e261dc8190",
+      "spec_hash": "sha256:faebdf1e6bc65d68687a6880c52a6c872323b33fe5f6529c782dc7c866566256"
     },
     "ext:msgpack:3.0.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:ec87d861610f07a6dfff1d7cde28c08b5641a294400fba624406327c48d3cefe",
-      "spec_hash": "sha256:bbe6250263cd25c10be3fe7e022c00bccc28029542fd28c414121970322caf6e"
+      "digest": "sha256:75208ea4c887b0e25eb4a82e8752636a18715cbf5a143901988730211c566554",
+      "spec_hash": "sha256:85f3c244c719e939e5d831b05ebeacd38b8ae5be9d6790c1fab6ba13b9056799"
     },
     "ext:msgpack:3.0.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:b81beabcbb6060f6a131618407594ff1a2e35bbc36858029a94779039675cc08",
-      "spec_hash": "sha256:63bfd6785e4ec37ed6655d60a5e237ac30220b235724767cdb11308e74e98809"
+      "digest": "sha256:da064c8fe122c38a03b3ba0dd49eaad9d865613609c104dbbc1b4f6438beb20c",
+      "spec_hash": "sha256:9a8bcd9da378f842b50ec1a5710037953b6aa1872a6c4a4a3dfb2441bc0918fc"
     },
     "ext:pcov:1.0.12:8.1:linux:x86_64:nts": {
-      "digest": "sha256:44260af79d48c2de6ec923a448de18ed160b6bed9d12c53f90ac8d0759a7ae1f",
-      "spec_hash": "sha256:48b36a646d8618514c1c1f284b90776ddbb02ce05f55a24cfe3316b5c5dd7880"
+      "digest": "sha256:69963327902dd8df6244daa8015d3eae011217829b7b718031d7f64bfed0d9f5",
+      "spec_hash": "sha256:44a90e484e70d7d1f3f0cdb66f9b27b1a8c8d8585a6f27543e42c713e99e6c22"
     },
     "ext:pcov:1.0.12:8.2:linux:x86_64:nts": {
-      "digest": "sha256:2db3f2a483e391cd53f7b91c47fc082cfa18c4db4319c8591ab00f287d96cb8f",
-      "spec_hash": "sha256:beb4a1e3565f5c8149eed09c4cd4411befb5943b3b51575492d372e6e1bf3ef3"
+      "digest": "sha256:da1e75cb4f6c2e1a76a03dada91aae3e08e2abf25947268e1afac13d56c47961",
+      "spec_hash": "sha256:8749b7815e210c444a35ef4d2176054040520ae1a2f14a7288dfcefeea783ce3"
     },
     "ext:pcov:1.0.12:8.3:linux:x86_64:nts": {
-      "digest": "sha256:b54d5d0bec0c1e88b7d2c6c3fb20428d4ed2264ef73c8028c16aba172aec51bf",
-      "spec_hash": "sha256:4a24ac75d4261d5da7befe53d711f371c83a175c86fa7add3f2e8e9b0432e666"
+      "digest": "sha256:5f56188b41876e8c2b384f05456d8c565fe154ad1cb70161bb85682306bcad18",
+      "spec_hash": "sha256:078114951dfeb05d49e974245f5ace7929ed1387ede78ca408cf85a61c730757"
     },
     "ext:pcov:1.0.12:8.4:linux:x86_64:nts": {
-      "digest": "sha256:124db36dcfadc5edf89559c3cc5f224ac2bce86c29fdfe184d641273c6ca8e8a",
-      "spec_hash": "sha256:d666082b28b0bb02f8946c13a99332842264322a8605bc546fab43da73c6b954"
+      "digest": "sha256:697c3992401abf8486987094962519af7e77c33c8c2e1bbd33abb84ac563c0f8",
+      "spec_hash": "sha256:5010a9aeb82bfa79b891bfcd99be1162f906a4e8a31d650cbfd6378ae6e93c7a"
     },
     "ext:pcov:1.0.12:8.5:linux:x86_64:nts": {
-      "digest": "sha256:0f8ac77ebf439a1797bc6475968d94d3169627c8f26eb5d5148e4904be196982",
-      "spec_hash": "sha256:75d240035f9b03dea904bb167d868995a492933c6618f69194c046dffcd88146"
+      "digest": "sha256:9348050b3959e69426b1b4312478824267b24bca9aec21d4fbdacb8d34fe3af4",
+      "spec_hash": "sha256:dd2dbed492a9aedb8c36e618aa8f350faa4ca1f297991e5d5cf92d7666bdc54a"
     },
     "ext:protobuf:5.34.1:8.2:linux:x86_64:nts": {
-      "digest": "sha256:2298225268107e2f1553d1ee4b3a3386dbcfa9d350ba15569bb0757b49228f83",
-      "spec_hash": "sha256:adc0b609549e64dd7e8f95d513dc99c424ca4a131ac8e728668ff66aea867540"
+      "digest": "sha256:8439642b5d0132a87b85ed173291032edef7f0d1aae3ab0ad9953f2b2e8139a7",
+      "spec_hash": "sha256:a2f16b1fd4cd840aaff174a3af05c683ada08bb61d96a2c885b66dc21313fe2c"
     },
     "ext:protobuf:5.34.1:8.3:linux:x86_64:nts": {
-      "digest": "sha256:77af7c18e582a96589d3b3ce21cf739e9ff5feee08275018479eac06700fce9c",
-      "spec_hash": "sha256:25ef49ba2d2b8e6c60133458428ee622aefa8f89cfa16b8c6e18c0567e30a382"
+      "digest": "sha256:6ce800be57a7b25b8f372939452bf99a628a1c4fb66aa28ff63abfbeb9496964",
+      "spec_hash": "sha256:c0e4acc3d5344ca967acc2a10357a34af3bae0eeef0030b2a91442a25652b550"
     },
     "ext:protobuf:5.34.1:8.4:linux:x86_64:nts": {
-      "digest": "sha256:1840ff0eaee8bccce8d79f6d8c38503e02b32658d05c8517f2d02e0e301d7a5c",
-      "spec_hash": "sha256:f5256db49b5c1f87a26fc59ab637e436bd461f1c5a5af6364f9301b223116edc"
+      "digest": "sha256:084da8a3ad6ee31b696898ca90b75316bb79344a0632d6f6fe4741a9302390bd",
+      "spec_hash": "sha256:9e238c29e5eb235a2104fc09bdfb19e08ca5faa36862c772259476f559411830"
     },
     "ext:protobuf:5.34.1:8.5:linux:x86_64:nts": {
-      "digest": "sha256:62ef99fefb86979dd1f72c89f646edb533361e14b8780346e6b13e952d8d59aa",
-      "spec_hash": "sha256:5f574f913fc46b3189403f75b92dcd65c98fac1ff3e76524ab975a000c1e853e"
+      "digest": "sha256:38974c5c41b4a22f00166898800a0891306d0762077feab5bc5e883afa914096",
+      "spec_hash": "sha256:3fd8615e6e4e83b38104ec942f1ef1d511a0cc25939878ff3e64d0a43276799e"
     },
     "ext:rdkafka:6.0.5:8.1:linux:x86_64:nts": {
-      "digest": "sha256:b823a6cd08b261cb38b4a7fdcc5fb7e0cf618110d8b54863b8e67c101dac24df",
-      "spec_hash": "sha256:e490840f612b82a17ba34678e78e9c36c33b43e7a605e56f71b6ab383a234682"
+      "digest": "sha256:20e5befbe27213b8a64d3ff89b5933f974ceb314ddff78964dfb7cb7b5bc5f01",
+      "spec_hash": "sha256:2b17dc19ee83f0d9507ffcbf6a15f885766db19552b9e8634c1d27809fa0c00f"
     },
     "ext:rdkafka:6.0.5:8.2:linux:x86_64:nts": {
-      "digest": "sha256:5c570a8dcce087511502b92a2d19cf17809e44fcf40d298fc3f2e2708408ab2b",
-      "spec_hash": "sha256:73e5caab45b6dc706f14d06bc1356cb1f3de0f6897e0bdfaf9695baef511ba37"
+      "digest": "sha256:5997c7cb3c821daba4b365306770a855b9352d74b8f40090616d26d4473e514a",
+      "spec_hash": "sha256:f0b883d5caacef154a55e09f8953062692ad683093ae6361ce7518ae335882ba"
     },
     "ext:rdkafka:6.0.5:8.3:linux:x86_64:nts": {
-      "digest": "sha256:3df11e2073e3c12586dba29e9f398834bfc50f028915f642766cc36bc0b669fe",
-      "spec_hash": "sha256:4942290399c3946ba49619d5b3c84305abf4d58a2053df5b8c3df75727b57374"
+      "digest": "sha256:15ce6e5e74b2024d9d2f4de7cd3433792a37e26dc04fb383626517b44f55f82f",
+      "spec_hash": "sha256:3b7c4cd3dee45a7adcfaf847b88486b211591edcbc1c9841872e7926bd72013a"
     },
     "ext:rdkafka:6.0.5:8.4:linux:x86_64:nts": {
-      "digest": "sha256:f01636eaaa762ddb06a609d47cab3653bcfa994346844884dd2fa6bb2067ff53",
-      "spec_hash": "sha256:c47c579c670618180d9ff224202c3e1183ca80e472a251acde0621d6921c02f5"
+      "digest": "sha256:052a7fb7d05d8e43dc49199fae1fd098d8a5d1c6bb847fac3f703582188414e0",
+      "spec_hash": "sha256:7518016b66062335be72b8c6ba2cbf8f936c52391318304f8f99ff8ac40473b6"
     },
     "ext:rdkafka:6.0.5:8.5:linux:x86_64:nts": {
-      "digest": "sha256:feea4855982419450e02a2a1b812d98be3b8daf45710ff403617888a9454366e",
-      "spec_hash": "sha256:92b31426b1dea4dde7715476793c8d6750473362ac7c7414326afe87b08723ea"
+      "digest": "sha256:5641f2bec32bc7a349cae4d8c11a56328fe110592b714ee20f6ecf8d6692525f",
+      "spec_hash": "sha256:23667de94648871a677601a07398f8f6cecda9eb02ea527ec83df522a2946738"
     },
     "ext:redis:6.2.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:6ac23ced5208f4c781e3687d63120023c7318f2bb89f987f733ff6f9228c2815",
-      "spec_hash": "sha256:ff3da77c4bd77489624c97a436dbb6c4bfe294206465ecfd6131881d22f2c779"
+      "digest": "sha256:e5cc26573f2dbb6824b870e29af56424d1ca605f591068a208982175673974d0",
+      "spec_hash": "sha256:f6ce58f47e3b10d5573830cfd243dac55b88a80625673e4b2c8c366f76c66b70"
     },
     "ext:redis:6.2.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:9dbc7af1647775f2b42d3e809e1bbacc63c47c9497af64c6aa8882e40b01472a",
-      "spec_hash": "sha256:ea8b5df8a5b3f19abe5b9eecf2467185807b2e08561eacf5ce4e7fba57758bb5"
+      "digest": "sha256:d4fe02639d012f02ad3232f6f429c9e9890160fe898c5ca51c161d96829eb7a6",
+      "spec_hash": "sha256:66fc361f7a5930e4e7ebd0e5a07cbd3a6246982639e24bf7a9445352ffc9084d"
     },
     "ext:redis:6.2.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:774b7827506add1b57194d359149790e9f0d79de9452111e49c26c2f8114e8d6",
-      "spec_hash": "sha256:394f9e6f546cb1bfef7348d9240532644e89e940ebadeb8db15a274d1674323e"
+      "digest": "sha256:fc4b0e1b11af17c1234f4f751fd55af9faa141e311f5505129770044b8e39fe6",
+      "spec_hash": "sha256:48ec58853e10e58c1bd61df3d368962b2cbb9a4ceb40df3701a7f0de2b520511"
     },
     "ext:redis:6.2.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:13020f4d88cee9dcd84449f7126ce1d462bc544678e539b39571efea531ca500",
-      "spec_hash": "sha256:f4e0898f93c8c18906a0fc1fda8a7c9f6873f9c4d8d67da3aded8061fa62f50c"
+      "digest": "sha256:c72bb4873659c8e6ee00f8d649aaef82b63447fa79a5c800c438840d4e1b076d",
+      "spec_hash": "sha256:461755af4b5a4bcea93a59f819d234416419eaa52e8532962d16775f1ec3efb1"
     },
     "ext:ssh2:1.5.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:28cbb2a2723855aa16d1e08a6958d31749ba23f82b8781cfae829e8c4445b427",
-      "spec_hash": "sha256:afacc98f59108d8aaa5e4ed98b99f4ee1e48d900f14668406d0dbb284e42b484"
+      "digest": "sha256:a41cfa34c68cd1bd27d385f0d55a7381f7f06975b80e30ea15ab27ae0dcd0df5",
+      "spec_hash": "sha256:7ef66a7fdb239992146206cf72421f987bd7ff88df38e87a79f3dcd67af1363b"
     },
     "ext:ssh2:1.5.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:1a94f26258a77d0e2b198cfb38e2ae1122521a1d426eac88636833de90c4d28c",
-      "spec_hash": "sha256:788e185176dd5737c1534058d65ceff7aff7eda64355045d0b0149bbdb7c74d9"
+      "digest": "sha256:75444ca6a9d76a7e5f3d9d871d31a86a79edd2ff15ea73231928da988e809f09",
+      "spec_hash": "sha256:0b65247dac3efa21c092ce282b55557bf11c2bb7b9eecf79115ad323cde0dd5a"
     },
     "ext:ssh2:1.5.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:27d779ac390f15efeec53be5fc653788bec13bd641f3f97e64a654311308b765",
-      "spec_hash": "sha256:3cb7a8e94b0b1e2a53d21be2782f906697e64fc9cee24c547830ec9b778e69c1"
+      "digest": "sha256:bf61434efb8392743030e88c37677275aea86f9a6b75143f756ff3cb5138f6b7",
+      "spec_hash": "sha256:6dc86f34ce1f49a1aa115d5761bd681cbb33a9d6c2192188bbe9bf40c4f4929a"
     },
     "ext:ssh2:1.5.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:67ace005b4ab26602d332e4340ed8281567b3dae85479292a4fbff05b2727f59",
-      "spec_hash": "sha256:485daf47e6f05744e2548163741c41059f1a52e17e09baecc3103002add9ccd1"
+      "digest": "sha256:6b0ae6f6b2159fc24f160534bc39ccd5fb53bccfed9a8fc8b525354b93b6c582",
+      "spec_hash": "sha256:87b3417b34ee1900b17ad5c5520222df1f24816062ab12f9a6e09f2ab05b51f7"
     },
     "ext:ssh2:1.5.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:2676ba36cf2f14b947d552426a6392351808ac379e2903ed6e258c22a7acb062",
-      "spec_hash": "sha256:38da1b14742ea99b098fcb06e159f9da01b022f4dc77f2e729045319c637ce8c"
+      "digest": "sha256:4dc6dc181ae1256fc97d23ac516ccee016076aa61de7439f1c86c0e673955db7",
+      "spec_hash": "sha256:41d4edd01f2ff1d4ebd74e024d181164f6f87b9e4589aff73b0e5e00897562f2"
     },
     "ext:swoole:6.2.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:2ae6b2d12dd00a8aefc483b10a5bd67f5d5ab742c6099e8acadf19940327d52a",
-      "spec_hash": "sha256:90149368f121a4ca7a4c7afb61515e0102654edd7426193271f488f6b6e14260"
+      "digest": "sha256:5d6c2689a5d09d60422fc2d564e8e25fd4cf5bef2f582d353c24263d6ef74eb1",
+      "spec_hash": "sha256:c92c6a1803a78b362a4790adc42bd8e0011f3db6219c4b129132e37dd30ed153"
     },
     "ext:swoole:6.2.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:eb15feefc781b41a3abe93400c69bf3f9d8e8a06660d0bc2f13f7e05687bf884",
-      "spec_hash": "sha256:f87e75d0ad40c4f3b6fad71491615cb7ff35c8363480c0783d155d069ad7d090"
+      "digest": "sha256:9cfbd45c8c39bcb4abd75f6a847e7701cc2e62e0a97d955caeef840c7ddf2530",
+      "spec_hash": "sha256:1fe85da1788170af2d2872ab24ffbbf4d7b8a05cc6bee90d8696d74a2b4cd081"
     },
     "ext:swoole:6.2.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:89ccc2933fe8b16df38415881114c3a74a39fd04ab0659b80fa45c217f3aa1d7",
-      "spec_hash": "sha256:1d389ff1c66c91026314750ff5146a972470dfc258ecc6c386e42889b6da4068"
+      "digest": "sha256:de617e0abbb9225cd150511416ec5e6eb3b1048584f83ee475ba64b419753788",
+      "spec_hash": "sha256:09c50420ac024fbffc5b08ae6668ea87d1f6f19908f196aee3c36d01de2bbcd1"
     },
     "ext:swoole:6.2.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:4ac74998a74e10b1ef5b43d946a15788378decde61d8c62a648508fbbe920838",
-      "spec_hash": "sha256:ce7ee5a6ec1d26818ef8d7dcff0ca526bd20955951efc214b689b7946c7098d7"
+      "digest": "sha256:b335b99e7774a8caff280bf35387acbc2eb1aa047d5405b1620d9b63a146550d",
+      "spec_hash": "sha256:d86046680eedb69dd00f123bec6e17c651b0547e1436805a7287978e575fa966"
     },
     "ext:uuid:1.3.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:c563b22e9207cd68064327f39052b8359a48342e18d330d441af5e3df22d8776",
-      "spec_hash": "sha256:9ada677d44a531b9a35aa4db631f95cf4deb1bee23703fd735fe4befb0508d3b"
+      "digest": "sha256:bf3f4885d5e147f519e40ae3a25c575c4ccaaeb802224677472bbec90d4931b2",
+      "spec_hash": "sha256:54302f207589c78f34e0e017b21590b0bad97c216f67b3435ca3fc6d930958de"
     },
     "ext:uuid:1.3.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:9669edf000d68e6f016687b8b0e85463c2e7a4a064828f532fd3f6c1de382f81",
-      "spec_hash": "sha256:81274a1bd4f1dfeb25304d34d2f7403507d0a9892c556c24a51079bc0372e8c0"
+      "digest": "sha256:6cc0447ec089ad4b97ecdcdbe3975fa8774dbeb2c96fcc5d3fe76fa8f260c538",
+      "spec_hash": "sha256:229c0051fd0ad0d55a3660945e7f69477c7cbeda4d50ebfad48ae32b9c9887e4"
     },
     "ext:uuid:1.3.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:154e77d16665309ada1527f2871aec5d6f8b29087c98c9178123311c3278f0a6",
-      "spec_hash": "sha256:a5bfb4e404a6dc25dda672ee53eb735094f565e8e876d0fdd6b2fba0cdecc0af"
+      "digest": "sha256:ae1550bf3e760eff1be5bf4e2caa955c3346613de502572763e46908783e1522",
+      "spec_hash": "sha256:015709ab257cc863d5b67d8547c6e32476932bd25c242b11722a967df0799fee"
     },
     "ext:uuid:1.3.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:35341e97c4d9d0d543ae1c461b643b6b95c909565e1f407bae6f47e160eea8c0",
-      "spec_hash": "sha256:2556779deceafdabb1c17b161a94ab4b150eecf51b9f082765da7ca290b29cb3"
+      "digest": "sha256:f68ab21effb7db94bc44cbd6ad6abdaf8f56fd33c679a3e84ad85f7bed20b31c",
+      "spec_hash": "sha256:dec75a3ea2815ff0efe7459a18005f0b9cf5759913bbdd98939767e3241e5db0"
     },
     "ext:uuid:1.3.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:d0e3ca331d90c614fe046fa3d2740b375286ec9788bf025ba2f19a4df437d144",
-      "spec_hash": "sha256:f60b28a3c094bc6bb708a67424a046e005a4bfc5ff1881265f90db0e9e9f699d"
+      "digest": "sha256:da25538f443adcfdeaedc1974236c3569cfd090454e4af0fc821a84ecf0ef71f",
+      "spec_hash": "sha256:48211ab1cb160008c91aa03cd68cf3cb712c921301b9ae94389141e86ddd6b24"
     },
     "ext:xdebug:3.5.1:8.1:linux:x86_64:nts": {
-      "digest": "sha256:ba0a14ce760cc2ed469016223f859e29da29d6c155f3e31538b50a9ccbb26260",
-      "spec_hash": "sha256:c467065709124e684c766ed4222493f8a6cd5fd842c741d6afcff970c29e724c"
+      "digest": "sha256:555b794fdeb6b7caeea8402aa99bf9c08ef54b3a392bbbf6575d253e746f5a44",
+      "spec_hash": "sha256:955f7f1f005079d14513d7ff418410a553aa442faaa4118ef4031df5dd048983"
     },
     "ext:xdebug:3.5.1:8.2:linux:x86_64:nts": {
-      "digest": "sha256:80e49d2ace93d60217af664de03ab754b0e97c3c01ebcda0d4ec65057952ee23",
-      "spec_hash": "sha256:9beb3cb5dcf582bdb957c5f742f09d360ff7aa3315341e7994ffed5a1e804dce"
+      "digest": "sha256:96064d3292fd2176d14fa18d576ce4a718d61cfadf30de3d86e5c822b8366eed",
+      "spec_hash": "sha256:df4d9af1ac7310bfb5990261ad773c4d10af35581043627a12aafb594d927f45"
     },
     "ext:xdebug:3.5.1:8.3:linux:x86_64:nts": {
-      "digest": "sha256:756ccf363d9f9c1eeb5b53a2e963d06712a36b8f87a4d039ff8c1c5018d6140a",
-      "spec_hash": "sha256:e863154336f2a906287ce1666e588559a0fb601206a5f292bf754750175208a3"
+      "digest": "sha256:e669b9159d08777dfcf913e21eaaef4cc9be2636d849d2ce3022cca836f1940b",
+      "spec_hash": "sha256:0ade98a242f3a41ed438d4a170aa436c2608a6336480e1b70a10ec53cef356e0"
     },
     "ext:xdebug:3.5.1:8.4:linux:x86_64:nts": {
-      "digest": "sha256:fbd152e46f72c0cbcca501720336fee5b1d5e6cab3058f30cba43c67bf6c2b40",
-      "spec_hash": "sha256:4d529175543f9ce3622f43f7ab760624bb5fcd0f2df3821d2118969d38111a85"
+      "digest": "sha256:08bf169a68dfc5602507409cfab7eb118d04328eb8de78d8a61140841cf756b8",
+      "spec_hash": "sha256:36c0be2faabee2eff06e9433991c44e09b9edce113f816c5b72154e3f77e2b8c"
     },
     "ext:xdebug:3.5.1:8.5:linux:x86_64:nts": {
-      "digest": "sha256:1dff39855232e7c843dbe790435d4bba19a4e506bdbaae032f21ed7b7a27a44b",
-      "spec_hash": "sha256:799a99a2cc4884ff517a434c8aa3d95ca8c71dad4e54dc0e24499889bfed6649"
+      "digest": "sha256:66c3a6f525b77d07a2257f2782b8c675a646cc7ee96358b086e0cd3d84773e3e",
+      "spec_hash": "sha256:d65eac220798327411a0042d653d8eeb34542524158f9cb17ff098c941c0195c"
     },
     "ext:yaml:2.3.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:6609099de9d0b6300b7005b4b5c7540c7608f0ef53503cde043e2f575dc81a11",
-      "spec_hash": "sha256:dc85f2aea58426e32de4a7a85eb9b4864e45ad0a6582a01bc0bf9e308fcf7433"
+      "digest": "sha256:59af23956422713951acd053b7a1672f0c03295146b031ffb34dc364012eb63c",
+      "spec_hash": "sha256:c6fd968304fa7f98c3a185c82bf2401f1ea1f9ee72ea54a8eb5d00b00827cb78"
     },
     "ext:yaml:2.3.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:52b9bf067c25b87c6ff44b3729cf7c263ee8a07f66da8f1240d6a815ee7faef7",
-      "spec_hash": "sha256:e8d03509b40494ac8277732e993561ced4b1c5d6e9b414773ebff7f1c82c3d93"
+      "digest": "sha256:234ad69f0729922fec35e0ee8e1b4b14ac46354c9e5e5bf52a507f2c891a15af",
+      "spec_hash": "sha256:9ada8a6d7dad80339e1fb6d1a593e0b53a84df4ce19f9579319a1c67a04312dd"
     },
     "ext:yaml:2.3.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:2afbf794a1519ef9bd72bf1cd814b5bbb442fe14d846ef74266b77c81c8cd341",
-      "spec_hash": "sha256:ddac9040e5c660e951a6584a8d71b5f8a0448699e9810aa8aae850918b05dd7e"
+      "digest": "sha256:8098da273d1538da2c67d60534d491c43a88109601ef9cef313fdadc06c6242d",
+      "spec_hash": "sha256:466327fa8dba10714ce8bc604a7b353d860595b91692b769f8894b77cd439a3c"
     },
     "ext:yaml:2.3.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:e913b53042555febd185a4c8ba23462f9261e7da446f0c887b90e4243e0b0cdf",
-      "spec_hash": "sha256:aa4f40923ed21979a1554b187ed799d0b669abcf66886315fff90b662e347430"
+      "digest": "sha256:958ffde7f9ab011f3155a802283b895b8aa5abc6e58bcc1df8228fa17ec74f8d",
+      "spec_hash": "sha256:9b0ca673d70e6b4ff977c12889f674ed9eb4b01ff1bdf5960a237fd299b89f6c"
     },
     "ext:yaml:2.3.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:c8434f639a015c2be2b3caf257decbf23c9154d316d53e6a18f9519812b7c812",
-      "spec_hash": "sha256:ec2aaa514f7baeab90a77b4467e793fc277de1582a8a474d69917506beddd07f"
+      "digest": "sha256:8994fb92f0a19c6de1724d44fd57ef0ee0cb7c4eaaa5177d8a3081d00a1b3ad3",
+      "spec_hash": "sha256:d8d9d529b06abe10adeb3211b324688327080ebc63705b76184c0a5ce9a48306"
+    },
+    "php:8.1:linux:aarch64:nts": {
+      "digest": "sha256:3384ab6e5f8bfa31b1e827dffe207a588212121bd5d1758df1e93533c8e9fc7d",
+      "spec_hash": "sha256:2bf5f7150c96b8c8581bbf85d5efb9b237929a95583167fee9703d18fd643315"
     },
     "php:8.1:linux:x86_64:nts": {
-      "digest": "sha256:efd03e7d8fa54b601fc765a4c8fc3a93cf62c93f0d18d775f648d666f27b278a",
-      "spec_hash": "sha256:a6e6be8bd2b24f646ed66beaead7ef2721c6e85a24760ed8997431e0863cbf5b"
+      "digest": "sha256:7c6a7dfbe016dc3eab98d260e9847e254cd9d37a96f391f743bde49f95b65e83",
+      "spec_hash": "sha256:5dddd2da6d6c5fa9479abe6395cc75cbe05f0a6612b079fa6a3162d0283de970"
+    },
+    "php:8.2:linux:aarch64:nts": {
+      "digest": "sha256:991ecdac4c4ceac88bd7ddbcec04a7d50295e1e065435553a40514ebe98683de",
+      "spec_hash": "sha256:5f7538fd2b86f5fe62d88325736e78c8f51003b07a9562ff99d70719c35f8aea"
     },
     "php:8.2:linux:x86_64:nts": {
-      "digest": "sha256:47e572abe189ae9ffec9c8dd304e653dcd590aa0941596d98f20976f37db3dfa",
-      "spec_hash": "sha256:926981c0300721f98728e28dce565dc3e5a7bbab3c2d9b7564b26b9071c5e2af"
+      "digest": "sha256:82c3e3358a8d8cfc2aa75d793bb0a55da925df6913e1efedeac90ae268f8fde4",
+      "spec_hash": "sha256:0eac1ddfd3963447a8fd78b05fc2cf91dbe1c5990dd57a995ffd84034c8bf096"
+    },
+    "php:8.3:linux:aarch64:nts": {
+      "digest": "sha256:ab0935bb57c792d1be382e8f2f84069d465a4b7f6b2c0e5d6717b4ad64ba719b",
+      "spec_hash": "sha256:f5e386eaaeb4e86ea28ada4b6b90a4bbcb8bbbaa5c05e6180e55f97d0bf1d065"
     },
     "php:8.3:linux:x86_64:nts": {
-      "digest": "sha256:3d2bc0d3c1b0cf2a0796d63650f6ea01fe8aff8a138e1d7bdaa99ec91ab03e59",
-      "spec_hash": "sha256:aa1ab983f6d0b4cf2dfd703aa224d800a2917a83f091c5c60f7f3d0ab5028a40"
+      "digest": "sha256:d523d7f4d6cd479b6e0bbf4e182411325d3d80024c473434fc0a2b2dfcaea3c0",
+      "spec_hash": "sha256:7031d07ee6fe00ff624c0bdc54e8e1aa0226523fbb1aa81c7f4a9de7aa369cbe"
+    },
+    "php:8.4:linux:aarch64:nts": {
+      "digest": "sha256:5c1d6e42da0af32452f370ea2f5f5f68cc97cbf3c91e0f29bb0f3581781b4aa2",
+      "spec_hash": "sha256:7471bc99e858985ff54fd8f807da0a632308aa7028cfc4fb9d3c428a73bb3023"
     },
     "php:8.4:linux:x86_64:nts": {
-      "digest": "sha256:9b1e47ff354c8a03e71a9223d0c5005d9bc83bd4ba17c2055e7c1ce54ecf108a",
-      "spec_hash": "sha256:f8fc1e3cb7ff8248b4c88c8eb6a767e845d6ac6166f51033c528a7f9aa272e3a"
+      "digest": "sha256:1622f77c2b74c462e5df50e6273ef3c3d4629224a8e5f37dbaa9ad66adaca44d",
+      "spec_hash": "sha256:fa3f6cf7896403e97e45e952d844a6b09a548ccfc3af7fcf2dbbd801e03082e9"
+    },
+    "php:8.5:linux:aarch64:nts": {
+      "digest": "sha256:f6db957ddd0fb099f6b967913ce97cd9f04b30093520b708a966b51adf0ef69e",
+      "spec_hash": "sha256:7768b637900f4ba83f841f29ca69d1c4bf00075171e61617865f1b3078338930"
     },
     "php:8.5:linux:x86_64:nts": {
-      "digest": "sha256:597ee0728e7966de8e97a60a7ead68d15e5b2118995b99f3db6353ff1f3e844a",
-      "spec_hash": "sha256:e797fcb0759061f587b9c3582ee394bfa366dead66f2479a473abd9a822fa291"
+      "digest": "sha256:3c01b8b75f93227559789edf5bc01b30e2424992d17b115d95ca1191bb7e6b5d",
+      "spec_hash": "sha256:b63b6561ac1a6db78e9ad98e0cf92f3d822a77619fb6d10dec44bb55b14645f0"
     }
   }
 }

--- a/catalog/php.yaml
+++ b/catalog/php.yaml
@@ -49,7 +49,7 @@ versions:
       sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
     abi_matrix:
       os: ["linux"]
-      arch: ["x86_64"]
+      arch: ["x86_64", "aarch64"]
       ts: ["nts"]
     configure_flags:
       common: >-
@@ -127,7 +127,7 @@ versions:
       sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
     abi_matrix:
       os: ["linux"]
-      arch: ["x86_64"]
+      arch: ["x86_64", "aarch64"]
       ts: ["nts"]
     configure_flags:
       common: >-
@@ -205,7 +205,7 @@ versions:
       sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
     abi_matrix:
       os: ["linux"]
-      arch: ["x86_64"]
+      arch: ["x86_64", "aarch64"]
       ts: ["nts"]
     configure_flags:
       common: >-
@@ -283,7 +283,7 @@ versions:
       sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
     abi_matrix:
       os: ["linux"]
-      arch: ["x86_64"]
+      arch: ["x86_64", "aarch64"]
       ts: ["nts"]
     configure_flags:
       common: >-
@@ -363,7 +363,7 @@ versions:
       sig: "https://www.php.net/distributions/php-{version}.tar.xz.asc"
     abi_matrix:
       os: ["linux"]
-      arch: ["x86_64"]
+      arch: ["x86_64", "aarch64"]
       ts: ["nts"]
     configure_flags:
       common: >-

--- a/cmd/phpup/main.go
+++ b/cmd/phpup/main.go
@@ -271,7 +271,7 @@ func main() {
 		xdebugFrag = compat.XdebugIniFragment(p.PHPVersion)
 	}
 	layered := compose.MergeCompatLayers(
-		compat.DefaultIniValues(p.PHPVersion),
+		compat.DefaultIniValues(p.PHPVersion, p.Arch),
 		xdebugFrag,
 		p.ExtraIni,
 	)

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -170,11 +170,18 @@ top of it.
 
 ### 2.4 `src/configs/ini/jit_aarch64.ini` (arm64/aarch64 only)
 
-Not fetched in this audit because PHP 8+ aarch64 ini content diverges (the
-upstream file sets `opcache.jit=off` for some PHP×arch combinations). **Gap**:
-confirm contents of `src/configs/ini/jit_aarch64.ini` before encoding in Go.
-Link:
-https://raw.githubusercontent.com/shivammathur/setup-php/accd6127cb78bee3e8082180cb391013d204ef9f/src/configs/ini/jit_aarch64.ini
+Audited 2026-04-21 against pinned SHA `accd6127cb78bee3e8082180cb391013d204ef9f`:
+
+| Key                       | Value  |
+| ------------------------- | ------ |
+| `opcache.enable`          | `1`    |
+| `opcache.jit_buffer_size` | `128M` |
+| `opcache.jit`             | `1235` |
+
+Only `opcache.jit_buffer_size` diverges from x86_64's §2.3 (`256M`). Encoded
+in `internal/compat.DefaultIniValues(phpVersion, arch)` by slice C1.
+
+Source: https://raw.githubusercontent.com/shivammathur/setup-php/accd6127cb78bee3e8082180cb391013d204ef9f/src/configs/ini/jit_aarch64.ini
 
 ### 2.5 Base ini file selection
 

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -82,18 +82,18 @@ func BaseIniFileName(iniFile string) (filename, warning string) {
 }
 
 // DefaultIniValues returns the ini key/value pairs that shivammathur/setup-php@v2
-// sets on Linux runners by default, before any user-supplied ini-values. The
-// caller merges the user values over the top so users can still override.
-//
-// Version-conditional defaults:
-//   - PHP 8.x (8.0–8.9): opcache.enable, opcache.jit, opcache.jit_buffer_size
-//     per compat-matrix.md §2.3 (jit_versions regex 8.[0-9]).
+// applies to every Linux run by default via its bundled ini templates. The
+// result is keyed by PHP minor version AND architecture — aarch64 diverges from
+// x86_64 on opcache.jit_buffer_size per v2's src/configs/ini/jit_aarch64.ini
+// (see docs/compat-matrix.md §2.4).
 //
 // Extension-tied defaults (e.g. xdebug.mode=coverage) are applied at compose
 // time by their respective handlers, not by this function.
 //
-// Data source: docs/compat-matrix.md §2.1 and §2.3; mirrored in testdata/default_ini_values.golden.
-func DefaultIniValues(phpVersion string) map[string]string {
+// Data sources: docs/compat-matrix.md §2.1 (base), §2.3 (x86_64 jit),
+// §2.4 (aarch64 jit); golden file testdata/default_ini_values.golden pins the
+// x86_64 form.
+func DefaultIniValues(phpVersion, arch string) map[string]string {
 	base := map[string]string{
 		"date.timezone": "UTC",
 		"memory_limit":  "-1",
@@ -101,7 +101,11 @@ func DefaultIniValues(phpVersion string) map[string]string {
 	if isPHP8x(minorOf(phpVersion)) {
 		base["opcache.enable"] = "1"
 		base["opcache.jit"] = "1235"
-		base["opcache.jit_buffer_size"] = "256M"
+		if arch == "aarch64" {
+			base["opcache.jit_buffer_size"] = "128M"
+		} else {
+			base["opcache.jit_buffer_size"] = "256M"
+		}
 	}
 	return base
 }

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -39,7 +39,9 @@ func TestUnimplementedInputWarning(t *testing.T) {
 }
 
 func TestDefaultIniValuesMatchesGolden(t *testing.T) {
-	got := DefaultIniValues("8.4")
+	// The golden file pins x86_64's expected keys. aarch64 branch has its
+	// own targeted cases in TestDefaultIniValues_PHP8xOpcacheJIT below.
+	got := DefaultIniValues("8.4", "x86_64")
 
 	want := map[string]string{}
 	for _, line := range readGoldenLines(t, "default_ini_values.golden") {
@@ -239,35 +241,48 @@ func TestXdebugIniFragment(t *testing.T) {
 }
 
 func TestDefaultIniValues_PHP8xOpcacheJIT(t *testing.T) {
-	for _, php := range []string{"8.0", "8.1", "8.2", "8.3", "8.4", "8.5", "8.4.5", "8.9"} {
-		t.Run(php, func(t *testing.T) {
-			got := DefaultIniValues(php)
-			want := map[string]string{
-				"date.timezone":           "UTC",
-				"memory_limit":            "-1",
-				"opcache.enable":          "1",
-				"opcache.jit":             "1235",
-				"opcache.jit_buffer_size": "256M",
-			}
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("DefaultIniValues(%q) = %v, want %v", php, got, want)
-			}
-		})
+	cases := []struct {
+		arch    string
+		wantBuf string
+	}{
+		{"x86_64", "256M"},
+		{"aarch64", "128M"},
+	}
+	for _, tc := range cases {
+		for _, php := range []string{"8.0", "8.1", "8.2", "8.3", "8.4", "8.5", "8.4.5", "8.9"} {
+			t.Run(tc.arch+"/"+php, func(t *testing.T) {
+				got := DefaultIniValues(php, tc.arch)
+				want := map[string]string{
+					"date.timezone":           "UTC",
+					"memory_limit":            "-1",
+					"opcache.enable":          "1",
+					"opcache.jit":             "1235",
+					"opcache.jit_buffer_size": tc.wantBuf,
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("DefaultIniValues(%q, %q) = %v, want %v", php, tc.arch, got, want)
+				}
+			})
+		}
 	}
 }
 
 func TestDefaultIniValues_NonPHP8(t *testing.T) {
-	for _, php := range []string{"7.4", "9.0"} {
-		t.Run(php, func(t *testing.T) {
-			got := DefaultIniValues(php)
-			want := map[string]string{
-				"date.timezone": "UTC",
-				"memory_limit":  "-1",
-			}
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("DefaultIniValues(%q) = %v, want %v", php, got, want)
-			}
-		})
+	// Below 8.x the opcache/JIT block does not apply on either arch;
+	// both archs return the same 2-key set.
+	for _, arch := range []string{"x86_64", "aarch64"} {
+		for _, php := range []string{"7.4", "9.0"} {
+			t.Run(arch+"/"+php, func(t *testing.T) {
+				got := DefaultIniValues(php, arch)
+				want := map[string]string{
+					"date.timezone": "UTC",
+					"memory_limit":  "-1",
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("DefaultIniValues(%q, %q) = %v, want %v", php, arch, got, want)
+				}
+			})
+		}
 	}
 }
 

--- a/test/compat/fixtures.yaml
+++ b/test/compat/fixtures.yaml
@@ -315,3 +315,38 @@ fixtures:
     extensions: 'imagick, mongodb, swoole, grpc'
     ini-values: ''
     coverage: 'none'
+
+  - name: bare-arm64-81
+    php-version: '8.1'
+    arch: 'aarch64'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-arm64-82
+    php-version: '8.2'
+    arch: 'aarch64'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-arm64-83
+    php-version: '8.3'
+    arch: 'aarch64'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-arm64-84
+    php-version: '8.4'
+    arch: 'aarch64'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-arm64-85
+    php-version: '8.5'
+    arch: 'aarch64'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'


### PR DESCRIPTION
## Summary

First multi-arch slice of Phase 2. Lands aarch64 support end-to-end for the PHP core bundle only.

- Workflow `runs-on` maps `arch == 'aarch64'` → `ubuntu-24.04-arm` (free arm64 runner for public repos). Applied to `build-php-core.yml`, `build-extension.yml` (scaffolding for C2), and `compat-harness.yml` (`ours` + `theirs` jobs, keyed on `matrix.arch`).
- `builders/linux/build-ext.sh` arch-parametrized (scaffolding for C2; doesn't fire in C1 since extension `abi_matrix.arch` stays `['x86_64']`).
- `internal/compat.DefaultIniValues` gains `arch` parameter; `opcache.jit_buffer_size=128M` on aarch64 per v2's `jit_aarch64.ini`.
- `catalog/php.yaml` — each of 5 version blocks' `abi_matrix.arch` grows to `['x86_64', 'aarch64']`.
- `test/compat/fixtures.yaml` — new optional `arch:` field + 5 `bare-arm64-<NN>` fixtures (one per PHP minor).
- `docs/compat-matrix.md` §2.4 — records audited `jit_aarch64.ini` values.

Extensions on aarch64 are **not in scope** — slice C2 handles that. Users asking for `extensions: redis` on arm64 will get a resolver error until C2 lands.

## v2 `jit_aarch64.ini` audit (2026-04-21)

```
opcache.enable=1
opcache.jit_buffer_size=128M
opcache.jit=1235
```

Only `opcache.jit_buffer_size` diverges from x86_64 (256M → 128M). Source: pinned SHA `accd6127...9f`.

## Test plan

- [ ] CI: planner emits 5 new core cells (one per PHP minor × aarch64) + 86 ext refresh cells (spec-hash churn from `build-ext.sh` hash change — content-identical rebuilds).
- [ ] CI: `build-php-core.yml` dispatches aarch64 cells to `ubuntu-24.04-arm` and produces bundles.
- [ ] CI: lockfile auto-commits 5 new `php:<ver>:linux:aarch64:nts` entries + spec-hash refreshes.
- [ ] CI: compat-harness runs 55 fixtures (50 x86_64 + 5 aarch64) across 165 cells, no new allowlist entries.
- [ ] CI: `make check` passes.

## Scope note

`docs/compat-matrix.md` §2.4 edit is scoped to exactly the §2.4 section. The repo's prettier config (`make check`) only runs on `src/` and `test/`, so the minor table-alignment drift elsewhere in `compat-matrix.md` isn't gated and isn't touched by this PR.

Spec: \`docs/superpowers/specs/2026-04-21-phase2-aarch64-c1-design.md\`