### PR TITLE
feat: easy+medium PECL extensions on aarch64 (phase 2 C2a)

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -63,6 +63,7 @@ jobs:
           EXT_NAME: ${{ inputs.extension }}
           EXT_VERSION: ${{ inputs.ext_version }}
           PHP_ABI: ${{ inputs.php_abi }}
+          ARCH: ${{ inputs.arch }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY: ghcr.io/${{ github.repository_owner }}
           WORKSPACE: ${{ github.workspace }}

--- a/bundles.lock
+++ b/bundles.lock
@@ -1,66 +1,126 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-04-21T17:22:57.807474034Z",
+  "generated_at": "2026-04-21T18:13:54.985366334Z",
   "bundles": {
+    "ext:amqp:2.2.0:8.1:linux:aarch64:nts": {
+      "digest": "sha256:5777547ce3dcfe4ceb34f59af0e3b9ef507bdfbc413e6811353d8bcc1d9c72c7",
+      "spec_hash": "sha256:0cb2946aa6fe74fd28fa5cf7c26841e1da80639d703f24d53bbca6324e3fb4e8"
+    },
     "ext:amqp:2.2.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:ba4c4c4f988737edd081e0a48c30c784b79894a83282e54f04dcb40d8d68db8c",
-      "spec_hash": "sha256:30c227a6566b4f6f967fbcc497e446bd898198f6a925e3d5bbcd0e4397907d88"
+      "digest": "sha256:31a46b578ad02b9bfea388dfeeb00d3671faa7a5de0714eb7e5bd288b0e67bf9",
+      "spec_hash": "sha256:987d0aa10c301ede66e4bf3553dca0e5f46acb6ece2e1310b3e96455c26b973f"
+    },
+    "ext:amqp:2.2.0:8.2:linux:aarch64:nts": {
+      "digest": "sha256:179436169336b9b8e17d2d2a083d8cd82fb813137ec39d3d58054b99a2b46297",
+      "spec_hash": "sha256:1158d3e745f22e797ee9b60b4adb901869f45923b7474a90e0ea331377389382"
     },
     "ext:amqp:2.2.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:3f048d25999e1a4d394c4a4d2230c8dc85b609ee3d3e112541fbf1dd1b6bc47b",
-      "spec_hash": "sha256:3cac0a34ed06af1812da25dcc0279d9b9a0a324f89e2ecb9fc7ecc3a3afc3d62"
+      "digest": "sha256:335c81db774900555b26b8cd50a39e39c44904570f52fc0b99b0762c609a6834",
+      "spec_hash": "sha256:28b95e2c46520c39e98b381c8d8a4994c0a729989e245d134ac502c64d522315"
+    },
+    "ext:amqp:2.2.0:8.3:linux:aarch64:nts": {
+      "digest": "sha256:1a5fa9ae5db2d668b7c493cc0b6ce87e97fd057bf75a75e9b18a74cf1667c6c5",
+      "spec_hash": "sha256:73612018bc08b38d1b5492365d6fed341f2f3caf4646dba959129d5a8bd5ca38"
     },
     "ext:amqp:2.2.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:aecaaccf96c4c8a9e5f1f51d49fab3e35a0ef1bcf04926801aef7629eceb5076",
-      "spec_hash": "sha256:618cef2b3118100f1c36fd4c33c0712fa17083857dad1378241de6bb35695994"
+      "digest": "sha256:4ac2eae38aaa9c651606bd6dc31c096482dcd83b58f427d2d37adcbf09195f39",
+      "spec_hash": "sha256:5c071e354f5f717e0dd50253b45a524a773c68dedff6ca8c81db4c7506518fb0"
+    },
+    "ext:amqp:2.2.0:8.4:linux:aarch64:nts": {
+      "digest": "sha256:7ffbf9c6af7a8f85fd6ae6510251525d54f038aa0702136ae9aae5de3ce9cb9c",
+      "spec_hash": "sha256:fba332e47541c5d04237e0e7895e40c88cec07940afc2e9fb913155f66789f8d"
     },
     "ext:amqp:2.2.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:2d1198f542a3c3add94985923aa726a851b48fce28fcf0988a04d97018447687",
-      "spec_hash": "sha256:527dcd9e2536373468e5bc6b011510cc68d189266cfe7fae5966473c47c85657"
+      "digest": "sha256:7bd5bf6938c813cc728cdae1160b806305e518a6c8fc0c4462a0348b03abe8fd",
+      "spec_hash": "sha256:2df6624c2a5f3018463547dbc61dc26824235618b3b14203d4f71c3ed3a3fd56"
+    },
+    "ext:amqp:2.2.0:8.5:linux:aarch64:nts": {
+      "digest": "sha256:1572d85017959f43e48b12e7e6b2594d697207f8f6fb2bff1dc123fb2e38721b",
+      "spec_hash": "sha256:c2e7602fb89e034f966a343a60ac7341ac98ead73e1b616c358c6a4160e4910f"
     },
     "ext:amqp:2.2.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:620c4c6484132c770da39962b365d9b9768e027e02f8a78848ca75664477d7d3",
-      "spec_hash": "sha256:9765f407ac6b0b355a691864477cc6bbfae488c53dad54c1f3ec45bc58621c0c"
+      "digest": "sha256:ed18d284cc0e674f2500c6cdbbedca91c11f3ba201779d730c4bfcb53f356feb",
+      "spec_hash": "sha256:4a382e5e8d08e83174f1a5c017d8085762b4065cda107df83a7f9f360040fa98"
+    },
+    "ext:apcu:5.1.28:8.1:linux:aarch64:nts": {
+      "digest": "sha256:c07a4075161d507f9be36db00ea7546be7500b684e40b3385b9bbf17c09caf63",
+      "spec_hash": "sha256:6a668056411960ea26608b1a1cccfe3d3a5b1c99731126ce1b1a59b822cec0aa"
     },
     "ext:apcu:5.1.28:8.1:linux:x86_64:nts": {
-      "digest": "sha256:67ea427f6bbdbd90833bf65257319e03dd26835670d3a70a8619c1782fea9728",
-      "spec_hash": "sha256:868f7a999cc3423bfe56945444e28e5bd4f37dc60970bc3f378f19a836a2ae49"
+      "digest": "sha256:ec7bde87b3c80a6df04cd79933334d973c4bbb400dfb4091c26811a4fab67243",
+      "spec_hash": "sha256:b9f3efd03aff86d307aff5d53c0a90d69ce45b5346e6f757908fcfa6d765d738"
+    },
+    "ext:apcu:5.1.28:8.2:linux:aarch64:nts": {
+      "digest": "sha256:f29a488c5b161260bc0b0f753c7a5feac720a9c9a3fe7a47373f6cabe22f651c",
+      "spec_hash": "sha256:1a80aa64ebafed6c7a6edf7340423d2908c92bb172bd2280a823fb5f763d73aa"
     },
     "ext:apcu:5.1.28:8.2:linux:x86_64:nts": {
-      "digest": "sha256:d6105f30f18e774c14f91fe5e7fc7089682fb63f959fbb093f8f0be7e1740172",
-      "spec_hash": "sha256:6a02708499d7ab18a47afb6c010bacf728a3219cb4a37be74822176e754a8058"
+      "digest": "sha256:f5197168f5fd047beb727b542633efa8ad923a8afd03adaace62c65e75d88fe5",
+      "spec_hash": "sha256:3819f820c17ce6ef8571815718f3ab11ad6cb79c31405632b125fc4a6d4d1243"
+    },
+    "ext:apcu:5.1.28:8.3:linux:aarch64:nts": {
+      "digest": "sha256:be92e979ab39600d09eb50927dbcf59b962185a04ecabd9d19e430c97f53cbf0",
+      "spec_hash": "sha256:baa1dfc14af12cf40ef05fd2a0359816f5c02475c7bfbf31341f966462b669f8"
     },
     "ext:apcu:5.1.28:8.3:linux:x86_64:nts": {
-      "digest": "sha256:a2ab963bef56076d197b61bc0d4626417e4f24233d3729a8e1d3cb47ff030c5e",
-      "spec_hash": "sha256:92bf73b0f5764d798fd0257d5d94794e44319a8962c7bad05dc7ae8559e4d484"
+      "digest": "sha256:fab0f7fb6c976437ae66ec4e926779c5408eeb4b2234c74ed63c7d6af5fae36a",
+      "spec_hash": "sha256:a311e890d5ab0fee5416a70a38951109eb89b017cd173f0e12cc1c3a4115ff6a"
+    },
+    "ext:apcu:5.1.28:8.4:linux:aarch64:nts": {
+      "digest": "sha256:eeb8d6894fd9c277e19820e79a00a32d2d533943e6433b525d6773ac2b7341f1",
+      "spec_hash": "sha256:727bb4cf0747e38317c6b53e7d3c60ac764ab66f9bec300cae7c7cb76e5b7762"
     },
     "ext:apcu:5.1.28:8.4:linux:x86_64:nts": {
-      "digest": "sha256:c9f8e34884e1ff61f064ebf497ecfab4903661678a32e537513fd0dac2d5401d",
-      "spec_hash": "sha256:767a3b0e2284c1966f768bed27a631432eda8c29ee6b3939c677c7d4c1705b8f"
+      "digest": "sha256:e9c58d05f2994f3eed94acb7bdbfc0279c5595bb5b079f2586a77890baf547bf",
+      "spec_hash": "sha256:5efec64da5d1f83941d0e96ff000660e12dbddf96be1ecfc4bcc41f84c5b4af4"
+    },
+    "ext:apcu:5.1.28:8.5:linux:aarch64:nts": {
+      "digest": "sha256:ae2c7d23133b308d8092891f9614343edd1c2b2d21bff3c71cc2baf74a0230fb",
+      "spec_hash": "sha256:5b2e36c9fe1f425e0b87c24142d810d180cda67d01fb23537b92e8d03dac9725"
     },
     "ext:apcu:5.1.28:8.5:linux:x86_64:nts": {
-      "digest": "sha256:733dbaa5b8dc5c1feadf8ef521bd676e2c40ea7887cd4f531dc32e59cb615e26",
-      "spec_hash": "sha256:0c198a89e676cdaa721801a9b33216a0fbcbb91d900136e157e4af61e6f671bd"
+      "digest": "sha256:12c3fc55be17fa4d5e559ab700ba0c5e26d8bafead4fb836cfa64dd83b937e50",
+      "spec_hash": "sha256:927ba567aaa24e8ecb8748afe16e7140cce2b628ff36347509291adce9d5093f"
+    },
+    "ext:event:3.1.4:8.1:linux:aarch64:nts": {
+      "digest": "sha256:65e1a9c626e4b95358c1e5b0fbd5f34cb6f7fa5479b97308c5df7e57eaff0da3",
+      "spec_hash": "sha256:cd528282a78a362b358c0639b1ddfefb0b64310efc1ed43172c9f9e843428693"
     },
     "ext:event:3.1.4:8.1:linux:x86_64:nts": {
-      "digest": "sha256:ed276ff5cb9a524abc051457d57c22b62d370011fc7d19faddb7b93e26773fec",
-      "spec_hash": "sha256:e97da991cbe6ddd4fc7097bbea204512c53163298703befb685b82d124f3ac47"
+      "digest": "sha256:6363bbc31d97717b5a4e17590687fde10e0bc76859c955a350bf3bc7ae7b1243",
+      "spec_hash": "sha256:04ad2a4c2aad71f4bbdd3486ca72d6c85ef9891cd778e69b082625b06f12aaa8"
+    },
+    "ext:event:3.1.4:8.2:linux:aarch64:nts": {
+      "digest": "sha256:b2287292b99617135d0729d49e7ef591cc22b74e0c19dae3fbb547019aa37853",
+      "spec_hash": "sha256:d0100cf36d722ecfd7422bc91c4f0511efad59b161e123ea86a2e25cf4af5f1f"
     },
     "ext:event:3.1.4:8.2:linux:x86_64:nts": {
-      "digest": "sha256:e9482ec7a065255b70e30312506f5f735dbd0c1b8e7aa4edb198db8c5a4630a3",
-      "spec_hash": "sha256:eb1ad5185fe7a290c001e8c8a815782c758fc29db48b0c6ed1d40ec4aa961a5c"
+      "digest": "sha256:5a775b66b6fc786015be54715afff7eaa51b58c71b3b9040fb52771e6cfb1c6c",
+      "spec_hash": "sha256:2383fa8b0f6d86ce3ff4ea81835c7889b10bd9b308e5c6deb53a0cc691156455"
+    },
+    "ext:event:3.1.4:8.3:linux:aarch64:nts": {
+      "digest": "sha256:ae9a2e27b459df14d3e05abf22d6a7eb12412faa142804495c3e97dedc0c16fb",
+      "spec_hash": "sha256:28bd456bbaf723ea74958e39890baa86f38623a554204a27c1858e8e64f071e8"
     },
     "ext:event:3.1.4:8.3:linux:x86_64:nts": {
-      "digest": "sha256:3014f3364c870c495503f12a4f57914432f3e16c52c1ce507b5de739a4f8b609",
-      "spec_hash": "sha256:dc99e4148dfb99e1133a4e341fbaab948671cb08788b3fa9d74b78e72b1f1765"
+      "digest": "sha256:4f6c2f81debe2704fed487d705d84534d718fce7ea46585ee0ed4817b08a49cc",
+      "spec_hash": "sha256:dad90af823e07ce74c8c0f86e626b38aa52aa14d627f4ee18b8a4b654b9c1526"
+    },
+    "ext:event:3.1.4:8.4:linux:aarch64:nts": {
+      "digest": "sha256:7af72d117377ca69eee9f8a8119c4518be7a5a07a6db8f7a711130fe4d5468e2",
+      "spec_hash": "sha256:ff3b0a138b17afb10b191b848f4224ac1e5308b87e3994e6968f39903cc2bf8c"
     },
     "ext:event:3.1.4:8.4:linux:x86_64:nts": {
-      "digest": "sha256:9052d18faf6315b9c4c1272e01526034658acca5ea67e656a8643bf8396f46bc",
-      "spec_hash": "sha256:cf3c1d3c80d1254ada997f5ac6782930a84cf164a254436b293ddccc87075f64"
+      "digest": "sha256:c1a26dfc5893a2e67fcc0acce370aba29f8d4d6bcfe9903ac5f1992d196306da",
+      "spec_hash": "sha256:85745ef4fafb832e250362aa01737e92bf616e80c66d1199ce1c3c2b65defa28"
+    },
+    "ext:event:3.1.4:8.5:linux:aarch64:nts": {
+      "digest": "sha256:90116ba9cc12852bac17e8577a3826a20d44cdad08a63d8e13bb57df4c8c8bb7",
+      "spec_hash": "sha256:1acd4bfbdc90cd9b29d7ac2b5afa436b4edfa0446e79d7e24256d1bc12726731"
     },
     "ext:event:3.1.4:8.5:linux:x86_64:nts": {
-      "digest": "sha256:18508879860d7a04a60b361e5253783af88838ce6f00fde93941938c88c9f08f",
-      "spec_hash": "sha256:edcd7f6b5e22bbb80d573f6d1eabb79d27a850f5c36ef5c34c12a357506c411a"
+      "digest": "sha256:237abc86ee062ab0ff5fd763fa1411dd0ced3d503a98bafe0562b6a2d28ffdca",
+      "spec_hash": "sha256:9bf40979d6ff860dc298f8140268f56afc354d23790259b45beec02fe6b5c92b"
     },
     "ext:grpc:1.80.0:8.1:linux:x86_64:nts": {
       "digest": "sha256:83e6bff82abd4b34a8f6cc0f5faf131cf7dc3807d5da9014ae63dc8ee86d39dd",
@@ -82,21 +142,37 @@
       "digest": "sha256:9bc85c5b6813980c768e58f07169c89ea2619dea860de9f8978af0adbdf875f0",
       "spec_hash": "sha256:39a3254b816b883e194a051ac9c97a1a947be871dcba5a1d5386e0aec2f408c2"
     },
+    "ext:igbinary:3.2.16:8.1:linux:aarch64:nts": {
+      "digest": "sha256:baf2cbe5d6ff93b53e768a59279e7f65452fc8c3084026fc944b9b3de703d8fc",
+      "spec_hash": "sha256:6c64fa6332f4441ce26c9da3ad425bb9d63b4db8d5195a62d851af7bc8a287dd"
+    },
     "ext:igbinary:3.2.16:8.1:linux:x86_64:nts": {
-      "digest": "sha256:51dbabc9159a24f7a19a2d57981ffb260a5c2275c9efe34bf8d7af7c995aa22e",
-      "spec_hash": "sha256:728f7f355d0c1bdb522831e09887fbb4b2aca089300636703b52598ce0a76791"
+      "digest": "sha256:30f52b5fba299cb77e23c2016e05b9cb7d0a04830b861edfe013ceb8779ce5a7",
+      "spec_hash": "sha256:f54d5ec417a50b357785466003de19abc29804cdc80d3b68c4978e32f93c5015"
+    },
+    "ext:igbinary:3.2.16:8.2:linux:aarch64:nts": {
+      "digest": "sha256:bffdf847e91b2ce75ec8cfa41d133e0831409e83a47685eeac8cd3ba5364817c",
+      "spec_hash": "sha256:0e2f5d8a5fa9fb76dc8e6a986852eea689eabf58cfc42e83cb1dac1433ec9c6a"
     },
     "ext:igbinary:3.2.16:8.2:linux:x86_64:nts": {
-      "digest": "sha256:9b4163a93a49ce9a17a0e793b1eec98b03f03c6fe0f8e9549c340513238fbe3c",
-      "spec_hash": "sha256:0ed654b215873f269e07c24ef64808aa59df2e13af23fd329a5db6b9754952d8"
+      "digest": "sha256:e8c6ba49f74ef6e1241cb15fee14ebf17bcca8e9762f6d9657733de0914ee343",
+      "spec_hash": "sha256:e66aa00ead004a007dd72a50ee51faea66826840cc00bae545144bc0bfd0074e"
+    },
+    "ext:igbinary:3.2.16:8.3:linux:aarch64:nts": {
+      "digest": "sha256:339cdfa3208cf18012fc9bd23f1364e09217df5150838fd56bff312cac2ebb55",
+      "spec_hash": "sha256:d29c3f8f756645e0069d41e31a981044e2c85ba5da28c2d0100da15006ed1118"
     },
     "ext:igbinary:3.2.16:8.3:linux:x86_64:nts": {
-      "digest": "sha256:9a3be3986dd8e3bb463a7cfd71abb16252428f455143c8e0562aad3378674f49",
-      "spec_hash": "sha256:18fbb0b2abcd7e4e0d81d780d9a819b9cc7f3e04a6e84253c698c1a9f40eac23"
+      "digest": "sha256:686e76bb8ecde654291fe013847ce33a46b4436496368754a124bd6fa55a3353",
+      "spec_hash": "sha256:09089954de1955957028e4860721394e55b83318a64a67af6753477889d7dbf8"
+    },
+    "ext:igbinary:3.2.16:8.4:linux:aarch64:nts": {
+      "digest": "sha256:6c6d2f6371232995bd993cf5505d1682f14ec57b1dd2ec069844fce81cf3f5ca",
+      "spec_hash": "sha256:c8cb70de9e7310c13f4a09db22e65bf68901f69d8093d4dbbeaf97080db91926"
     },
     "ext:igbinary:3.2.16:8.4:linux:x86_64:nts": {
-      "digest": "sha256:309b514a14b942c72c3ebd43ac6b96579701ac546ff32787c6315f6fff30fb8b",
-      "spec_hash": "sha256:ce13f83111e59ee963579664ae4270b0dbdec8b35501a19af2cec507a5596424"
+      "digest": "sha256:fe74f21acfa307bad5fc4895828948f342daeff4956fd016ba34f05309536da6",
+      "spec_hash": "sha256:b57ddab84da3aa4e4085260e7958a06bcee7df3783e5c5f6b34444c04b5d0c73"
     },
     "ext:imagick:3.8.1:8.1:linux:x86_64:nts": {
       "digest": "sha256:ea38456897fe2a1f8b1252c46f3416597574d41dbd34b69f7b0b57172dbbd11b",
@@ -118,25 +194,45 @@
       "digest": "sha256:c5fbdd5b9900bf0339af60da0f4ee544fe36765482e2ab051607efe2129513f1",
       "spec_hash": "sha256:338e5476d7d4f9b20eaf2240fa0558b488a03951f6fbc965e0684299beb90670"
     },
+    "ext:memcached:3.4.0:8.1:linux:aarch64:nts": {
+      "digest": "sha256:d0e3588212961fe24368c81a1ff7543833134f15a047e00ec838328872e476d5",
+      "spec_hash": "sha256:412c71975520e4f5b29f4870c88d34ab08d7cd7330ad0f880087c233917c941d"
+    },
     "ext:memcached:3.4.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:64ecf925845c4357fde80c396c1afb28d2f4510f3e3adf9f728f61c9b15808d6",
-      "spec_hash": "sha256:af1a682fd584e18513a14098603da147062864054d0c1b0760c6640e21b51759"
+      "digest": "sha256:b5c48009ee14a9321604c6338d0c74d4483e7816555e60182b95d27cceb1cbeb",
+      "spec_hash": "sha256:55fd08c9b141bd85778443f272dd4f8810c9c176bafb3758c602f002e09e2b7b"
+    },
+    "ext:memcached:3.4.0:8.2:linux:aarch64:nts": {
+      "digest": "sha256:4af5322aa43ba645a770417a68d49c448f9e00e22dea93f88d774d761725f086",
+      "spec_hash": "sha256:cefb5211ef99340d39b4ff8c1f73e5c7da8284ee59afa95b613a1bd0ec2cf22e"
     },
     "ext:memcached:3.4.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:d884ff4e3f4a4ff14e350403ca4b50d191a3500cb3c71bd687e8d88a45b5a39e",
-      "spec_hash": "sha256:1260d0f4fd4e5db15aff1832a75f0f395929bbfeff627ec088dbabac6a96820a"
+      "digest": "sha256:3f3202746c125923aaa23c0ed28b15123d3e36cbf3ecac07fef1f8efabf9ee79",
+      "spec_hash": "sha256:0559fb49ed252a6d8d5558e0fc317f283b75ae0b540bed7281882d1e8784646b"
+    },
+    "ext:memcached:3.4.0:8.3:linux:aarch64:nts": {
+      "digest": "sha256:b161133ae23a5bbff3c16fa3dfa17c6228298e461ee639fc0db8443ad57c4cb8",
+      "spec_hash": "sha256:0d7803f7083490b0c37b51ee37029b4d91a80376d461f22a351f20f622393e17"
     },
     "ext:memcached:3.4.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:67f39bd7bbb150d2c64fb2ae18032ed044f2a1e05ae6bf99bbc98bdfd612fd07",
-      "spec_hash": "sha256:a8ea84818178fac59c3c17afad91ea94403b3113ae5f1651a10dbfa58cf2513d"
+      "digest": "sha256:8a195dd5343f30eccd65258fd5a406352612721ba60003e3540982f5f8f2a216",
+      "spec_hash": "sha256:320f421665d5445ae61d601ba8c02774d74db9ee020d2f52532f35446daa0ee9"
+    },
+    "ext:memcached:3.4.0:8.4:linux:aarch64:nts": {
+      "digest": "sha256:608cd31d1f20e260cbf268db478c8a963be97ed4607424d0f61f1a253e322159",
+      "spec_hash": "sha256:11a4b3b6016838166b6d4e2f25f85cfb46d65be8e48604fe31d657adc2b8ba66"
     },
     "ext:memcached:3.4.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:66539008607b5ae54ebcef0624fabc55c8e0916658176aa55d51251b466d71be",
-      "spec_hash": "sha256:e190bbdb396ed86f8b44e938553c22bdb158b3f237e0faffaae6c90f917edc9d"
+      "digest": "sha256:b2eefef29de3190637cbf630330b71349df19bad31527520824378b9afb09962",
+      "spec_hash": "sha256:aacca7eaa5371a9349b7e307f387533c5e13fe6cfea7db976808382aee17ca6d"
+    },
+    "ext:memcached:3.4.0:8.5:linux:aarch64:nts": {
+      "digest": "sha256:59c80f9a386d5979af307e80b1b1ed1ef986b50dc2825210f9a46010874b5db1",
+      "spec_hash": "sha256:268dc8300d259b8204bc2a242ab8b3821b56c09da2d04ef0f9ea5b5fc9458ed9"
     },
     "ext:memcached:3.4.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:22edf2ca18683778dd9d6c7963cd6700cc5a2ce0b348aff854d362c4dc8ab1b1",
-      "spec_hash": "sha256:cb079cc94d798f29a1006adecf4f50f9253395f7abbf426dc3aae4282ff1d4f0"
+      "digest": "sha256:488684c4fcee12f1772a03e85a3150db0eb02de46401693c7099b84429a7ca3b",
+      "spec_hash": "sha256:6d8c68c316caada1a1b3a8280a8d15a1c94fc9867eb10d9ff3a399d587a8e6af"
     },
     "ext:mongodb:2.2.1:8.1:linux:x86_64:nts": {
       "digest": "sha256:8803231f3c7d97c68b453ce57982daa35c031c005800481da8aa0dbb94d5ff8f",
@@ -158,117 +254,229 @@
       "digest": "sha256:ba4ef7b889a7730e53b7c5267cbd27ee2570408dc8a8421b249fedd061f9a6b5",
       "spec_hash": "sha256:5c0f1f549d12023632109076d9d4a97256765662790a0e4d30387da26120a195"
     },
+    "ext:msgpack:3.0.0:8.1:linux:aarch64:nts": {
+      "digest": "sha256:1a0c0e724f5b83a369ace4e4aa901793c59acbef503e17234a311295b40663f3",
+      "spec_hash": "sha256:82e492a0c2912116fc2d628e88af3fa290ba60c2ff26a84fb542f8dba2237dc4"
+    },
     "ext:msgpack:3.0.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:4175bd0e01cef1a3eeb37632e11d0f66ce8f30fa2ad07198669a64dca1d07437",
-      "spec_hash": "sha256:25e7f0e49cf21bf59f6b95c24dc01d6b2f2b5e36a89c8ed400b9245c3e7dd7e7"
+      "digest": "sha256:32cc378315a80d2980e6497af519dd443c86452737a7575c501a241cb0cb7d71",
+      "spec_hash": "sha256:013be7fc83baa3bc7974a0490fa712c39fec60465d5b8d357a0069e3243ec1f8"
+    },
+    "ext:msgpack:3.0.0:8.2:linux:aarch64:nts": {
+      "digest": "sha256:bbc8b5bcfdb2b6920547dc2a3aba33f65df9d9258755d9c23404985f52d552d8",
+      "spec_hash": "sha256:72844c17aafbfb66834d5e77b89822b9b26405225b95d7e825c0e64f1d6fb046"
     },
     "ext:msgpack:3.0.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:7ad276c1eb1a8bc5774735612d06cb1eb34bab19757dca41e280414c1f1feba8",
-      "spec_hash": "sha256:9cbc0e9519cec85834c9acb6ffd252786e079abca47edec58c4ba1e3b31e9dad"
+      "digest": "sha256:9857a68fa71685321552b2381865f3a247b870ae3b9ab63776eae9c3c28a0bb4",
+      "spec_hash": "sha256:1dcc499e4ad41eca23f4b7df0690f1eb8b9a9cdbaf9d8a39bb2cd362aae1bf8f"
+    },
+    "ext:msgpack:3.0.0:8.3:linux:aarch64:nts": {
+      "digest": "sha256:50043998d76bb78453150a0522fcf18b7a953c28359607fba493c1e74a925444",
+      "spec_hash": "sha256:5bc35931a6a89da999ad0da7ef7c92b04b00055d9a86824c9ec7f9e2d5c3ed23"
     },
     "ext:msgpack:3.0.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:c60d5914fe2813c77d23c5314a724d85dfbb3e89fee9145a2d65c3e261dc8190",
-      "spec_hash": "sha256:faebdf1e6bc65d68687a6880c52a6c872323b33fe5f6529c782dc7c866566256"
+      "digest": "sha256:7f3f8d635cded058132a5342ffa506c73e654148994349f9a6696e58c69a5503",
+      "spec_hash": "sha256:73530d143003254d9cba89bd3018c94264663863b75277fffbc07efec948bc70"
+    },
+    "ext:msgpack:3.0.0:8.4:linux:aarch64:nts": {
+      "digest": "sha256:bbb3973cccb14dbc01d5719d9a7a3778612bf2c4017bb13a3bc64e944ea24429",
+      "spec_hash": "sha256:da1ad0e189c16deaced3804ae6ebe8e667000f4b2a11078211f98a881a1abe6d"
     },
     "ext:msgpack:3.0.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:75208ea4c887b0e25eb4a82e8752636a18715cbf5a143901988730211c566554",
-      "spec_hash": "sha256:85f3c244c719e939e5d831b05ebeacd38b8ae5be9d6790c1fab6ba13b9056799"
+      "digest": "sha256:36b69d4b9497ea5311de9d8b5bfa71c6c3fab2a081445ac6fa19bb9549a2da9e",
+      "spec_hash": "sha256:fc14c166bca16fcdf0a2120462e53ec22dde1402b45ceac67fb2f35847e1f5ed"
+    },
+    "ext:msgpack:3.0.0:8.5:linux:aarch64:nts": {
+      "digest": "sha256:41c58d71d0547adc01239a230aaad9c1d0e6f7e7606719612c5e19444dc2b987",
+      "spec_hash": "sha256:6b10831da129eac7c151522b9a4327c502ed6436d2dbb13ac58c23a137dc4aaf"
     },
     "ext:msgpack:3.0.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:da064c8fe122c38a03b3ba0dd49eaad9d865613609c104dbbc1b4f6438beb20c",
-      "spec_hash": "sha256:9a8bcd9da378f842b50ec1a5710037953b6aa1872a6c4a4a3dfb2441bc0918fc"
+      "digest": "sha256:3e95d8c5f28048cb7bd64963d1d389fef190556c5fdd1b2cfa2831bc92746ae5",
+      "spec_hash": "sha256:c9abc53e766b2b4d0c089b05de81246e825e638dccf1cf8e66e6800ac5998aa9"
+    },
+    "ext:pcov:1.0.12:8.1:linux:aarch64:nts": {
+      "digest": "sha256:3b35663cb8a501b49909cd931f1f7278fd70a55e7298d890e82f71ad2a43bc55",
+      "spec_hash": "sha256:c9b8f1f0b238e43161c1704cd14b4001ed1f24593c84517f87253c7a8df49245"
     },
     "ext:pcov:1.0.12:8.1:linux:x86_64:nts": {
-      "digest": "sha256:69963327902dd8df6244daa8015d3eae011217829b7b718031d7f64bfed0d9f5",
-      "spec_hash": "sha256:44a90e484e70d7d1f3f0cdb66f9b27b1a8c8d8585a6f27543e42c713e99e6c22"
+      "digest": "sha256:6875858c5bc2b68ba18a47835109a7ae007827561c1db7fc8c007107037ef2a4",
+      "spec_hash": "sha256:3a0842dc0abb81d75785328b4c2dd2b09e3ce330b845a1c9d96ef3ac302d6b3e"
+    },
+    "ext:pcov:1.0.12:8.2:linux:aarch64:nts": {
+      "digest": "sha256:bcf6d553026cad40a30b1c05b43039a60762fe238aac0fbf2b013d60da5005bc",
+      "spec_hash": "sha256:c08c0ea3f47ab57caa8fea3900d72956bb60fb08bb9cb69fbf2af36fdc129b8a"
     },
     "ext:pcov:1.0.12:8.2:linux:x86_64:nts": {
-      "digest": "sha256:da1e75cb4f6c2e1a76a03dada91aae3e08e2abf25947268e1afac13d56c47961",
-      "spec_hash": "sha256:8749b7815e210c444a35ef4d2176054040520ae1a2f14a7288dfcefeea783ce3"
+      "digest": "sha256:5be48df84517c09f8e18e00763841b38153358dd8f6b74510061f0710a09759f",
+      "spec_hash": "sha256:74a001bdae181bd13dbe99e75b1972122e99619dce678f34da3f16f0cb233505"
+    },
+    "ext:pcov:1.0.12:8.3:linux:aarch64:nts": {
+      "digest": "sha256:6408b8993de6ca90cd346dac4912380d2ebe30bf534aa20bb134b7318aeb3995",
+      "spec_hash": "sha256:ead5f9bf2ea7df64a9fd301943256067eaaee81d24b30b729edc864dbc260c4b"
     },
     "ext:pcov:1.0.12:8.3:linux:x86_64:nts": {
-      "digest": "sha256:5f56188b41876e8c2b384f05456d8c565fe154ad1cb70161bb85682306bcad18",
-      "spec_hash": "sha256:078114951dfeb05d49e974245f5ace7929ed1387ede78ca408cf85a61c730757"
+      "digest": "sha256:dceeb2ec0c7f1c8992f6bbdf58881922464e785f787b2562d9573eb836999fb8",
+      "spec_hash": "sha256:e9cbe86a8b22444f7ecfe3d81a4f9e62340b029cd7487cab1a90b2bfde39d6ec"
+    },
+    "ext:pcov:1.0.12:8.4:linux:aarch64:nts": {
+      "digest": "sha256:a67d9b158bf776504734e11ad19d7f51efa21d1d7daa845e98c90b2a3a0dbcd8",
+      "spec_hash": "sha256:48174907de692e142357145cbb1906ed67e927b4785fcdba940ff86e44f8c46d"
     },
     "ext:pcov:1.0.12:8.4:linux:x86_64:nts": {
-      "digest": "sha256:697c3992401abf8486987094962519af7e77c33c8c2e1bbd33abb84ac563c0f8",
-      "spec_hash": "sha256:5010a9aeb82bfa79b891bfcd99be1162f906a4e8a31d650cbfd6378ae6e93c7a"
+      "digest": "sha256:bacc589f2c61270f4d764a06e8be2cff0cb5584664e49bcd13b86f94f7e2f2e6",
+      "spec_hash": "sha256:21a3576d59158f07737118ebd621e2499fae465b06096b5aab12dc4276efe29f"
+    },
+    "ext:pcov:1.0.12:8.5:linux:aarch64:nts": {
+      "digest": "sha256:b0d1ab66b13cb5c8775f6967132da09764ecd6c9177ab9cc91804133ccb36b26",
+      "spec_hash": "sha256:3a5c49055352cc555989fd4f3873230c52408490afd4a463eaa90396075f8364"
     },
     "ext:pcov:1.0.12:8.5:linux:x86_64:nts": {
-      "digest": "sha256:9348050b3959e69426b1b4312478824267b24bca9aec21d4fbdacb8d34fe3af4",
-      "spec_hash": "sha256:dd2dbed492a9aedb8c36e618aa8f350faa4ca1f297991e5d5cf92d7666bdc54a"
+      "digest": "sha256:0b41ae3d3ba8e2fde367f10c203096cdfdd7cdf56297807efd27b1bb5b908c01",
+      "spec_hash": "sha256:fe4e5510c44db80d5b8768ab47e6d63261b5c221c4a1dc1de41dccfcdc4fa0c9"
+    },
+    "ext:protobuf:5.34.1:8.2:linux:aarch64:nts": {
+      "digest": "sha256:8ecea10a59399452e8802be1a5f1167eb5811ce6b2108c1903fdde21c4e4e1e2",
+      "spec_hash": "sha256:5601d90794a23d05614e118806aebfd0273ad1758ee9eeaa335c0898c3d2f710"
     },
     "ext:protobuf:5.34.1:8.2:linux:x86_64:nts": {
-      "digest": "sha256:8439642b5d0132a87b85ed173291032edef7f0d1aae3ab0ad9953f2b2e8139a7",
-      "spec_hash": "sha256:a2f16b1fd4cd840aaff174a3af05c683ada08bb61d96a2c885b66dc21313fe2c"
+      "digest": "sha256:7fd6cb211aa9a4cf3bbf4621c8125a7a22a90f0d80f1d1850fc29e15d4f137cb",
+      "spec_hash": "sha256:5875aada7d45523acdc64540dd25e5b284118887281676dfd5410aca3cf8f703"
+    },
+    "ext:protobuf:5.34.1:8.3:linux:aarch64:nts": {
+      "digest": "sha256:afae1f826030bdce1f498ef5fddab97cf56296532a9ea72f889c01606fde3298",
+      "spec_hash": "sha256:aedf0f8e62a6a887f38d02fb456dbda97769a9612bfe0562a433abec65d56c74"
     },
     "ext:protobuf:5.34.1:8.3:linux:x86_64:nts": {
-      "digest": "sha256:6ce800be57a7b25b8f372939452bf99a628a1c4fb66aa28ff63abfbeb9496964",
-      "spec_hash": "sha256:c0e4acc3d5344ca967acc2a10357a34af3bae0eeef0030b2a91442a25652b550"
+      "digest": "sha256:fca817ace5966cabe1138bc024ab1dc404cea9283e138bd71725ad4fe360d240",
+      "spec_hash": "sha256:84f5543d8619acc7b4845383716a183b40557331d23aff85d03ceef0f41f446d"
+    },
+    "ext:protobuf:5.34.1:8.4:linux:aarch64:nts": {
+      "digest": "sha256:a4a36a8f2923880456a807cbb1625983877b9543bcfd82d9f97c2ab1a584fb4a",
+      "spec_hash": "sha256:73d2a6a003a684a289db494dff09e94e0a9183a3ca988baa68b3f54fa130bdd3"
     },
     "ext:protobuf:5.34.1:8.4:linux:x86_64:nts": {
-      "digest": "sha256:084da8a3ad6ee31b696898ca90b75316bb79344a0632d6f6fe4741a9302390bd",
-      "spec_hash": "sha256:9e238c29e5eb235a2104fc09bdfb19e08ca5faa36862c772259476f559411830"
+      "digest": "sha256:7692f99b7c9fc9e3bd84931552a7b46a2845cf42387275c1be0a8c146c445042",
+      "spec_hash": "sha256:3aa6f31e59869329dc65389dc3fee6ab1a59e73bd6cfffc5e771c1aa9d52b12c"
+    },
+    "ext:protobuf:5.34.1:8.5:linux:aarch64:nts": {
+      "digest": "sha256:3f774108bfc92f46a024b6d92c972272368f8535b869887d28f3165541b56094",
+      "spec_hash": "sha256:688ad099da15e031e921a71da27cb608a2ac5a1d743452c4bcde6141855e6183"
     },
     "ext:protobuf:5.34.1:8.5:linux:x86_64:nts": {
-      "digest": "sha256:38974c5c41b4a22f00166898800a0891306d0762077feab5bc5e883afa914096",
-      "spec_hash": "sha256:3fd8615e6e4e83b38104ec942f1ef1d511a0cc25939878ff3e64d0a43276799e"
+      "digest": "sha256:fb45ee60ac4744e0930e6a225234841ce9b74638f8593edc26ca7796299cb76e",
+      "spec_hash": "sha256:5451b4a36a20e46462e393c7a29f72dd2916cc8aecabf03d5af5d4ddc85eea17"
+    },
+    "ext:rdkafka:6.0.5:8.1:linux:aarch64:nts": {
+      "digest": "sha256:fdd29856a39796162ad6bfd146fed43ec706e74e3b330353b8870af75c2c9f1c",
+      "spec_hash": "sha256:e5cd9a89fd93d56b7371a26f69358e7031cd67a2701708c80a51083f1c5a001a"
     },
     "ext:rdkafka:6.0.5:8.1:linux:x86_64:nts": {
-      "digest": "sha256:20e5befbe27213b8a64d3ff89b5933f974ceb314ddff78964dfb7cb7b5bc5f01",
-      "spec_hash": "sha256:2b17dc19ee83f0d9507ffcbf6a15f885766db19552b9e8634c1d27809fa0c00f"
+      "digest": "sha256:4b8fe1edbf9a0ce549f99ed44c85442f0815b45c5ec6f439ce2d5175901bf91b",
+      "spec_hash": "sha256:51f5b2bc23e39020733072ec8fa56cf5fdeed3816cb07089ba1a9a7e61aba2ca"
+    },
+    "ext:rdkafka:6.0.5:8.2:linux:aarch64:nts": {
+      "digest": "sha256:6141115b3f26936f7e0b0e3a4fe98f2278d339228eef4b1d42056c359baec8cc",
+      "spec_hash": "sha256:c432ce2412ebf48f550a82c6a2c077206912a15fcc19690567839608129d05e5"
     },
     "ext:rdkafka:6.0.5:8.2:linux:x86_64:nts": {
-      "digest": "sha256:5997c7cb3c821daba4b365306770a855b9352d74b8f40090616d26d4473e514a",
-      "spec_hash": "sha256:f0b883d5caacef154a55e09f8953062692ad683093ae6361ce7518ae335882ba"
+      "digest": "sha256:1b9176cf38b011cb76d9dfa217b6282ac93b43a995b267e92d1b7248c0a228da",
+      "spec_hash": "sha256:74346942bb7f10b80ccedd32e270a984311d29df144a3f52642df3fff123bcdc"
+    },
+    "ext:rdkafka:6.0.5:8.3:linux:aarch64:nts": {
+      "digest": "sha256:6c045b2aa8a22d73497dcbec1be753fc9f57004bb47aedf0ce78112f17f06f8f",
+      "spec_hash": "sha256:692fa98055e0397ee1218604aa21eb616267107a7d9050af1c0dfa0dd5bb2494"
     },
     "ext:rdkafka:6.0.5:8.3:linux:x86_64:nts": {
-      "digest": "sha256:15ce6e5e74b2024d9d2f4de7cd3433792a37e26dc04fb383626517b44f55f82f",
-      "spec_hash": "sha256:3b7c4cd3dee45a7adcfaf847b88486b211591edcbc1c9841872e7926bd72013a"
+      "digest": "sha256:e01449c68ab95bf07cbfe2e6d0c2bf4123ee32e27e1602b045ca936778f6c7a4",
+      "spec_hash": "sha256:10b337db286705ab192d8ae6102aead653ab26f7061cb26a88b3b41ddb0a31cb"
+    },
+    "ext:rdkafka:6.0.5:8.4:linux:aarch64:nts": {
+      "digest": "sha256:a946924777a922939f00bf4f4b401bc09e0dcf70696c93fa830643cbdba433a3",
+      "spec_hash": "sha256:26f88e6afbd1fa421ce14fac78691578a2b6695dacff2a33b00ee2a0466542bb"
     },
     "ext:rdkafka:6.0.5:8.4:linux:x86_64:nts": {
-      "digest": "sha256:052a7fb7d05d8e43dc49199fae1fd098d8a5d1c6bb847fac3f703582188414e0",
-      "spec_hash": "sha256:7518016b66062335be72b8c6ba2cbf8f936c52391318304f8f99ff8ac40473b6"
+      "digest": "sha256:62042ca6d7123e0b0a1052c057d354e34a64ff018f2f7e09d640026a54d9765d",
+      "spec_hash": "sha256:dd9628d280e0d483f858e08272e14271e4244db7bc6b8d3bbdbd8e57c9b0b5c7"
+    },
+    "ext:rdkafka:6.0.5:8.5:linux:aarch64:nts": {
+      "digest": "sha256:3494b7c1bffe60c81d1b3ee1c95524694860fb3f1e50db92c070f27fe103314e",
+      "spec_hash": "sha256:084e5082345601d3ef716ca57986e5870640b66b9187d655e750e7a5016a38f5"
     },
     "ext:rdkafka:6.0.5:8.5:linux:x86_64:nts": {
-      "digest": "sha256:5641f2bec32bc7a349cae4d8c11a56328fe110592b714ee20f6ecf8d6692525f",
-      "spec_hash": "sha256:23667de94648871a677601a07398f8f6cecda9eb02ea527ec83df522a2946738"
+      "digest": "sha256:697d9d489f968184c1d33611c0d29e4d8dc424e43955847ed0bba5ef46faab8a",
+      "spec_hash": "sha256:0c8240393c71faa6ef71faa5f2d760cb0307f4f199a4ea25c50164dcf88cfecb"
+    },
+    "ext:redis:6.2.0:8.1:linux:aarch64:nts": {
+      "digest": "sha256:237b2fffa6ba109a0c25938de08b399acbcdd23fe3343128738600fde21cf9e0",
+      "spec_hash": "sha256:211f9bb7d006452328d7a2819e6f97fa94998e7f91dab849f395902a90c51393"
     },
     "ext:redis:6.2.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:e5cc26573f2dbb6824b870e29af56424d1ca605f591068a208982175673974d0",
-      "spec_hash": "sha256:f6ce58f47e3b10d5573830cfd243dac55b88a80625673e4b2c8c366f76c66b70"
+      "digest": "sha256:38d1134731972cfc6af3f3fd1cf264c4660fe8f620aec115d867d7641099155b",
+      "spec_hash": "sha256:1615a8ce28541014ee6cf640b9b3251aefca4b877038ab141f01c6da3ba4bdec"
+    },
+    "ext:redis:6.2.0:8.2:linux:aarch64:nts": {
+      "digest": "sha256:c7a2d4d6e18f5ff5a50dcf1b3b27b64bece7118935e53ce0cf63d8855be312ed",
+      "spec_hash": "sha256:85419674786187ea0273d2bfd20e06985043d799085a0fa8d8ddd98c8619206c"
     },
     "ext:redis:6.2.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:d4fe02639d012f02ad3232f6f429c9e9890160fe898c5ca51c161d96829eb7a6",
-      "spec_hash": "sha256:66fc361f7a5930e4e7ebd0e5a07cbd3a6246982639e24bf7a9445352ffc9084d"
+      "digest": "sha256:2f972f02ceff69878249ea1ae5f0b91afd08556bec7f93a7194b3b54aa911a3e",
+      "spec_hash": "sha256:c4271c7bea6e5d8868bc014e6ed3fdd9e62b8f423ab9f845c49ef6f9daced75c"
+    },
+    "ext:redis:6.2.0:8.3:linux:aarch64:nts": {
+      "digest": "sha256:8c79dcbabb65fb77063ba959d91eae8cb1bc04c3e9d9a5ee9c0e4414bace5b08",
+      "spec_hash": "sha256:e5a10cb754c359d0a0e5d30365b53470d273165e95d4f5f25b91bd14398cb79b"
     },
     "ext:redis:6.2.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:fc4b0e1b11af17c1234f4f751fd55af9faa141e311f5505129770044b8e39fe6",
-      "spec_hash": "sha256:48ec58853e10e58c1bd61df3d368962b2cbb9a4ceb40df3701a7f0de2b520511"
+      "digest": "sha256:28ecf9c70ad3203289bbb99153c3123a0ade1b12d389472ce7bc29bf370ce937",
+      "spec_hash": "sha256:c09a273f9efc29ec8a7a15eed8dba0cbe27dc0534deb7e011491dec84233656e"
+    },
+    "ext:redis:6.2.0:8.4:linux:aarch64:nts": {
+      "digest": "sha256:8eb000fd804e953c0b57f409f810b63db8cfd1c88774623ef138076403a0973f",
+      "spec_hash": "sha256:1e31ac222ab348afb1d7620d4bec6f463dd70d054cab6fd1ededc5bf4441456a"
     },
     "ext:redis:6.2.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:c72bb4873659c8e6ee00f8d649aaef82b63447fa79a5c800c438840d4e1b076d",
-      "spec_hash": "sha256:461755af4b5a4bcea93a59f819d234416419eaa52e8532962d16775f1ec3efb1"
+      "digest": "sha256:cf038d7a4957972aa4eb67471564ddd0372f89d8996545605d6826143d074cef",
+      "spec_hash": "sha256:1a58befd7df23299c6a7f612b6ffdbf95f194f40d9a0c552c4507efeb8c1bb1c"
+    },
+    "ext:ssh2:1.5.0:8.1:linux:aarch64:nts": {
+      "digest": "sha256:574170b78d4e8047b96d48f4a9aaf9a609d500c79ec2e015b5027d471cf5b321",
+      "spec_hash": "sha256:7bcd556b4172bd9c459c118002e7f92d847e4f0259d9f2d0144bbd8526a577ba"
     },
     "ext:ssh2:1.5.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:a41cfa34c68cd1bd27d385f0d55a7381f7f06975b80e30ea15ab27ae0dcd0df5",
-      "spec_hash": "sha256:7ef66a7fdb239992146206cf72421f987bd7ff88df38e87a79f3dcd67af1363b"
+      "digest": "sha256:868a1df6166c8c615be398f8ed1211a97a2c637bbb11fae7e96a6973ba52a248",
+      "spec_hash": "sha256:5bc726776f6b5b4c1ab6e0018663f4133477b5e1fb1e691cf0c595742dc3fce0"
+    },
+    "ext:ssh2:1.5.0:8.2:linux:aarch64:nts": {
+      "digest": "sha256:dcfdaa9d3649ecf95468b91cb3e400e7a17980eab36d832de60344b112c8cad1",
+      "spec_hash": "sha256:56a57b150577f9b7bae6a3673e9b7d02c4cf1f644cf934271e81bae3c8ebb667"
     },
     "ext:ssh2:1.5.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:75444ca6a9d76a7e5f3d9d871d31a86a79edd2ff15ea73231928da988e809f09",
-      "spec_hash": "sha256:0b65247dac3efa21c092ce282b55557bf11c2bb7b9eecf79115ad323cde0dd5a"
+      "digest": "sha256:ae41993f28a34b771dcd2d6d51f80bb3c3b7b5b0f19b5bd928c84ab90c6c0b1b",
+      "spec_hash": "sha256:b894b57266efb2312668a90551ac44c5a23421ee22cea6e69adf255e40d84a05"
+    },
+    "ext:ssh2:1.5.0:8.3:linux:aarch64:nts": {
+      "digest": "sha256:39ecad79b310de621550664b61ea8add325070cc23d43020ceda37524d547882",
+      "spec_hash": "sha256:1b7bb1696121560322b3a02b9e2c1eb25615543f5baf10169c05ed87f6f5dd0a"
     },
     "ext:ssh2:1.5.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:bf61434efb8392743030e88c37677275aea86f9a6b75143f756ff3cb5138f6b7",
-      "spec_hash": "sha256:6dc86f34ce1f49a1aa115d5761bd681cbb33a9d6c2192188bbe9bf40c4f4929a"
+      "digest": "sha256:12918d6ffe9adc06621261db8c38ae7613ecfd15e77eec58c4cfcea9d3d79809",
+      "spec_hash": "sha256:a2ce353abc64c3a9b80d903fb9949c63d2ef55867be15a482deccac814addc9d"
+    },
+    "ext:ssh2:1.5.0:8.4:linux:aarch64:nts": {
+      "digest": "sha256:b1c4e0b843a690dd8967eb32fe9850a8dd50aebf0f1ea2c1ee8df72c4d002a15",
+      "spec_hash": "sha256:c8207f641433a93449dc534c47ed68b6cff6323355d61f8d97c1e3d65d7fa76e"
     },
     "ext:ssh2:1.5.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:6b0ae6f6b2159fc24f160534bc39ccd5fb53bccfed9a8fc8b525354b93b6c582",
-      "spec_hash": "sha256:87b3417b34ee1900b17ad5c5520222df1f24816062ab12f9a6e09f2ab05b51f7"
+      "digest": "sha256:87384835b2adb81123d9ec317137d06f519fc26b61b05cc040a6ce34a181ec61",
+      "spec_hash": "sha256:02e1c2f021917f4ad4ea5176f2adcec147e07ca2fa24d6325c61275edf3af345"
+    },
+    "ext:ssh2:1.5.0:8.5:linux:aarch64:nts": {
+      "digest": "sha256:330a51b6c5c87c8c770d89eb84c63610b89119e6dae7b74d6eccc3ed64cfe798",
+      "spec_hash": "sha256:e77b47debdf04d9100340afed2dafb5c3857fcaec374acc33563ae969b2fd29d"
     },
     "ext:ssh2:1.5.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:4dc6dc181ae1256fc97d23ac516ccee016076aa61de7439f1c86c0e673955db7",
-      "spec_hash": "sha256:41d4edd01f2ff1d4ebd74e024d181164f6f87b9e4589aff73b0e5e00897562f2"
+      "digest": "sha256:11775cf94e34430d89f4900ad85991f5dcaa6c2a3949598ec466f7f7def2c122",
+      "spec_hash": "sha256:8d477ca05899e8c7702a6e81d7606d4c6f7f58ca0bfa84e08e3f6dc59b075884"
     },
     "ext:swoole:6.2.0:8.2:linux:x86_64:nts": {
       "digest": "sha256:5d6c2689a5d09d60422fc2d564e8e25fd4cf5bef2f582d353c24263d6ef74eb1",
@@ -286,65 +494,125 @@
       "digest": "sha256:b335b99e7774a8caff280bf35387acbc2eb1aa047d5405b1620d9b63a146550d",
       "spec_hash": "sha256:d86046680eedb69dd00f123bec6e17c651b0547e1436805a7287978e575fa966"
     },
+    "ext:uuid:1.3.0:8.1:linux:aarch64:nts": {
+      "digest": "sha256:a3d8dbe7d09ac192ec5a202fc22c73a141dfcb7f53a6781f882ae09038db7138",
+      "spec_hash": "sha256:78247dc9b80a9ff99632294a9eaccc0291ce7e3e4df6648a2ee5ed6fcb9b2db6"
+    },
     "ext:uuid:1.3.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:bf3f4885d5e147f519e40ae3a25c575c4ccaaeb802224677472bbec90d4931b2",
-      "spec_hash": "sha256:54302f207589c78f34e0e017b21590b0bad97c216f67b3435ca3fc6d930958de"
+      "digest": "sha256:50b2e7ea8f44509f948238175e9668b2fd001f77fb7b85e2e5805118b96fd066",
+      "spec_hash": "sha256:c73ca3f633d72b59ecca689c655dca0bf2a14815680ca754405241ccfcc1671a"
+    },
+    "ext:uuid:1.3.0:8.2:linux:aarch64:nts": {
+      "digest": "sha256:bdc4dc3848549f95be0b03d6a2a70dfed9a1251214dbc99d2d56448abf7a96a4",
+      "spec_hash": "sha256:7077b7589b61d26bf63c13d060f432e599488f6f156da99e7d7c84af4daddc14"
     },
     "ext:uuid:1.3.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:6cc0447ec089ad4b97ecdcdbe3975fa8774dbeb2c96fcc5d3fe76fa8f260c538",
-      "spec_hash": "sha256:229c0051fd0ad0d55a3660945e7f69477c7cbeda4d50ebfad48ae32b9c9887e4"
+      "digest": "sha256:9ac88af95c3c5b653e09b4d39e5a239f58e2eeaed27db2f9b4961bb07bca7ee2",
+      "spec_hash": "sha256:285bf666b39f777b6debb807c325cb04d3f3e6384468ff2e5cb5547396c519a3"
+    },
+    "ext:uuid:1.3.0:8.3:linux:aarch64:nts": {
+      "digest": "sha256:3e0a0cbbf1aa58e68a697c09edc85cf5483e4ea264985e393bbc55ea64c0f097",
+      "spec_hash": "sha256:9de9c260a598aef2bacf5e10f8a0ac34ff58b610f699d7a7cffc16b7990cb797"
     },
     "ext:uuid:1.3.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:ae1550bf3e760eff1be5bf4e2caa955c3346613de502572763e46908783e1522",
-      "spec_hash": "sha256:015709ab257cc863d5b67d8547c6e32476932bd25c242b11722a967df0799fee"
+      "digest": "sha256:c2dc55237c37b94f55d76a1695f3c8499f5d5b78073be5b2f7ff7d15f6a33d9b",
+      "spec_hash": "sha256:95fd1951e7389bf10502302cfcd7b2b60e4d2cf716202c50ff327b711a3bbc0c"
+    },
+    "ext:uuid:1.3.0:8.4:linux:aarch64:nts": {
+      "digest": "sha256:1f9d6adc7baa18a320668ef685f6131eacc081fb8ce168d3939be44944f5c762",
+      "spec_hash": "sha256:c31acb657b2dfce79610da7b05cf372614f37a1ba7ba9827c3caa28dc25176b5"
     },
     "ext:uuid:1.3.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:f68ab21effb7db94bc44cbd6ad6abdaf8f56fd33c679a3e84ad85f7bed20b31c",
-      "spec_hash": "sha256:dec75a3ea2815ff0efe7459a18005f0b9cf5759913bbdd98939767e3241e5db0"
+      "digest": "sha256:03359bf987e3acbb5878bddf83298ea6d93a96ea103d759606f6284785e24b6a",
+      "spec_hash": "sha256:bbcb290832d2d85c208a5b13a15195a7c11189390231563f502cf2db4f6bf79f"
+    },
+    "ext:uuid:1.3.0:8.5:linux:aarch64:nts": {
+      "digest": "sha256:39a9b04596f37f0cb64b7e7a2925238d2565ee722681d450cabe3906ae3875a1",
+      "spec_hash": "sha256:3b6f32ecd3b19a79b1077dd1514e7343a6402e391c0d5515f23761f07de93700"
     },
     "ext:uuid:1.3.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:da25538f443adcfdeaedc1974236c3569cfd090454e4af0fc821a84ecf0ef71f",
-      "spec_hash": "sha256:48211ab1cb160008c91aa03cd68cf3cb712c921301b9ae94389141e86ddd6b24"
+      "digest": "sha256:7844abdd3ab16181bfda0f27f5329fe4b4522ed83828b335834de0b534e5929f",
+      "spec_hash": "sha256:3d6c89457edca19e1df68111cc77756a78a9d1b74a50278a445c2e11c4b4787c"
+    },
+    "ext:xdebug:3.5.1:8.1:linux:aarch64:nts": {
+      "digest": "sha256:13fa045ee464e8115d0b1ec85da766c5de9c6eb84de8c14ad7876a83036c5049",
+      "spec_hash": "sha256:f2602e553cc9fc0a355d0b0cc4e6c81cfe5f9efad5e8b72edfbf8285343ca50d"
     },
     "ext:xdebug:3.5.1:8.1:linux:x86_64:nts": {
-      "digest": "sha256:555b794fdeb6b7caeea8402aa99bf9c08ef54b3a392bbbf6575d253e746f5a44",
-      "spec_hash": "sha256:955f7f1f005079d14513d7ff418410a553aa442faaa4118ef4031df5dd048983"
+      "digest": "sha256:19d09af0edbf37bec0e3242b2fabb7bfbe904f240e2079a2deea2883ecda0431",
+      "spec_hash": "sha256:81a2262f5311715e1ffb104970073f01871c0ea4701ed0b87e89283846529f31"
+    },
+    "ext:xdebug:3.5.1:8.2:linux:aarch64:nts": {
+      "digest": "sha256:14a2beaef62a5e56f1a4042119678b3959c502b149789ad4051ac739efb56efc",
+      "spec_hash": "sha256:6a64816add8a2fb6df0884f9ce331c06fa45fe0ef3f324f9ec739fcc256fefa4"
     },
     "ext:xdebug:3.5.1:8.2:linux:x86_64:nts": {
-      "digest": "sha256:96064d3292fd2176d14fa18d576ce4a718d61cfadf30de3d86e5c822b8366eed",
-      "spec_hash": "sha256:df4d9af1ac7310bfb5990261ad773c4d10af35581043627a12aafb594d927f45"
+      "digest": "sha256:4bf53b9f64d2edd980a4e90c950da15729a23b7a69cff437b468277a2567f39e",
+      "spec_hash": "sha256:8c5359f2143779343f6b04e1cb0635aee5047fe4c8165744569e84e62d211335"
+    },
+    "ext:xdebug:3.5.1:8.3:linux:aarch64:nts": {
+      "digest": "sha256:dd5e7564cf448e004abdc75ee33baef19461f0771638f0fadc15a2f838cf0921",
+      "spec_hash": "sha256:daab083a3e2ce265ffb86b8797022ec8df04f9af2f3854f7ac3d51450bd1df79"
     },
     "ext:xdebug:3.5.1:8.3:linux:x86_64:nts": {
-      "digest": "sha256:e669b9159d08777dfcf913e21eaaef4cc9be2636d849d2ce3022cca836f1940b",
-      "spec_hash": "sha256:0ade98a242f3a41ed438d4a170aa436c2608a6336480e1b70a10ec53cef356e0"
+      "digest": "sha256:1ddc266a5e4215f0d0e933743711bcac8c0e2786c367e09e0b77def7a9361d21",
+      "spec_hash": "sha256:940ad57b75be14055203d4ba3c95d7b2f07e7e57926167b57806804ce6219c13"
+    },
+    "ext:xdebug:3.5.1:8.4:linux:aarch64:nts": {
+      "digest": "sha256:f6232aa94f0ef704af5679233df25cbac941ae63b986e5e6dbaa2f3786be5018",
+      "spec_hash": "sha256:afc0b630f4d18aa4093ba96452ecdf5a50c68bddec58abb927a2ed6d7b9d45dc"
     },
     "ext:xdebug:3.5.1:8.4:linux:x86_64:nts": {
-      "digest": "sha256:08bf169a68dfc5602507409cfab7eb118d04328eb8de78d8a61140841cf756b8",
-      "spec_hash": "sha256:36c0be2faabee2eff06e9433991c44e09b9edce113f816c5b72154e3f77e2b8c"
+      "digest": "sha256:58e5be7c54297d0b1883df77e8f0dcaf9331a893689df63b0aef618e5a23aca5",
+      "spec_hash": "sha256:07d68833d738bc2fc996849d4b613618c18dcb1f14c6180aff34e0795d1939cf"
+    },
+    "ext:xdebug:3.5.1:8.5:linux:aarch64:nts": {
+      "digest": "sha256:62fa6e93f2751ad6dafcbe85e66c1cff3b898f195eb6a00a823c545a90796712",
+      "spec_hash": "sha256:03716cacfebc5348c93601dd859d82f00672c9fdb94679d37a2b9ca2989bbc4d"
     },
     "ext:xdebug:3.5.1:8.5:linux:x86_64:nts": {
-      "digest": "sha256:66c3a6f525b77d07a2257f2782b8c675a646cc7ee96358b086e0cd3d84773e3e",
-      "spec_hash": "sha256:d65eac220798327411a0042d653d8eeb34542524158f9cb17ff098c941c0195c"
+      "digest": "sha256:225aabb7549e434ef16dafd78416250a706da4baebf5793b2dea6552436d84d1",
+      "spec_hash": "sha256:346e905f618b7a822ee8fdfcb730c04415b6f5813194f5b5253f121254d841fc"
+    },
+    "ext:yaml:2.3.0:8.1:linux:aarch64:nts": {
+      "digest": "sha256:e60bd8523384aabf3cf85cefcda998f2f206eb9d5bb3bfb37503135b7382bacf",
+      "spec_hash": "sha256:2e17758ffb54ed542c07cf8e62c249f4e6cad6b6b9b2f1aeb9f67451f4562f50"
     },
     "ext:yaml:2.3.0:8.1:linux:x86_64:nts": {
-      "digest": "sha256:59af23956422713951acd053b7a1672f0c03295146b031ffb34dc364012eb63c",
-      "spec_hash": "sha256:c6fd968304fa7f98c3a185c82bf2401f1ea1f9ee72ea54a8eb5d00b00827cb78"
+      "digest": "sha256:14affd83906cceaf444c9ef9e1efcaa5b08bb9e5addfe1887558b85c30d686d4",
+      "spec_hash": "sha256:7ba976f8bff84efb3e22cc5e2d464e795f58ec2e5e50806ecdb537a9be73cab2"
+    },
+    "ext:yaml:2.3.0:8.2:linux:aarch64:nts": {
+      "digest": "sha256:de46503a3402e7300f774ba10d349a5627b281b98d69f5a3cdbfc664c0897f0e",
+      "spec_hash": "sha256:32f39eb457aac30934f04901bc8e08bd5c12b7b1aebf434df567de90116ec35f"
     },
     "ext:yaml:2.3.0:8.2:linux:x86_64:nts": {
-      "digest": "sha256:234ad69f0729922fec35e0ee8e1b4b14ac46354c9e5e5bf52a507f2c891a15af",
-      "spec_hash": "sha256:9ada8a6d7dad80339e1fb6d1a593e0b53a84df4ce19f9579319a1c67a04312dd"
+      "digest": "sha256:e56284eb4f2dd1c9e419b2a655a1db466d7c76940fd594348b0d07703260b705",
+      "spec_hash": "sha256:6fe32c9e7932a3adb42320afd9f20260f1216531ac3f7e5e27a04033516c8c66"
+    },
+    "ext:yaml:2.3.0:8.3:linux:aarch64:nts": {
+      "digest": "sha256:babab4bc12a62915c4021ae7821eca459ed0ed31e7025862761bd1e1450fffdd",
+      "spec_hash": "sha256:51440bf38a230600e959ae8f94461bd6f1272d841e31f32cd0e062d97832556c"
     },
     "ext:yaml:2.3.0:8.3:linux:x86_64:nts": {
-      "digest": "sha256:8098da273d1538da2c67d60534d491c43a88109601ef9cef313fdadc06c6242d",
-      "spec_hash": "sha256:466327fa8dba10714ce8bc604a7b353d860595b91692b769f8894b77cd439a3c"
+      "digest": "sha256:9f9d2e112f1e2ff987a42b9c590e7b238cad5bf37ab9909b47dd98f8dfcdc6dd",
+      "spec_hash": "sha256:6f39620cc4e04a3037094dbc148f63412b7d4706bf4b3f8d2405f8a3f47a1696"
+    },
+    "ext:yaml:2.3.0:8.4:linux:aarch64:nts": {
+      "digest": "sha256:8975a9e004216a97f477835565446229130aced85082d25cbe11fedddc7363c4",
+      "spec_hash": "sha256:b35c5d9e335dc4ec0a4c837e35ea2d6a787efeb690c99f840157743daa01397b"
     },
     "ext:yaml:2.3.0:8.4:linux:x86_64:nts": {
-      "digest": "sha256:958ffde7f9ab011f3155a802283b895b8aa5abc6e58bcc1df8228fa17ec74f8d",
-      "spec_hash": "sha256:9b0ca673d70e6b4ff977c12889f674ed9eb4b01ff1bdf5960a237fd299b89f6c"
+      "digest": "sha256:6f944747ff2634906aaa95a60205d8f9bdeeca33eba4722e040637c7db3c0907",
+      "spec_hash": "sha256:5c959fb60079d453edcf97f53cc3197c4a7f78c4d91f3a6f0800413e7d25377a"
+    },
+    "ext:yaml:2.3.0:8.5:linux:aarch64:nts": {
+      "digest": "sha256:296117cbdccb54d1ee2478dcc83c74ca5fc46c7511165a1ee966a4a9660314a4",
+      "spec_hash": "sha256:4b9975505e1cf0b1d92326766b7df82c13689c5eb135b77560d2bb99ee21f4c6"
     },
     "ext:yaml:2.3.0:8.5:linux:x86_64:nts": {
-      "digest": "sha256:8994fb92f0a19c6de1724d44fd57ef0ee0cb7c4eaaa5177d8a3081d00a1b3ad3",
-      "spec_hash": "sha256:d8d9d529b06abe10adeb3211b324688327080ebc63705b76184c0a5ce9a48306"
+      "digest": "sha256:e690a98976ae284a2d24683f4b9b1bc06e9438c75fc5009ce110e12d9ff591d5",
+      "spec_hash": "sha256:914f69970805880412d4bc48bd8ec5bf0e21c8bc44bf8e9f057bb96c0b44393a"
     },
     "php:8.1:linux:aarch64:nts": {
       "digest": "sha256:3384ab6e5f8bfa31b1e827dffe207a588212121bd5d1758df1e93533c8e9fc7d",

--- a/catalog/extensions/amqp.yaml
+++ b/catalog/extensions/amqp.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: ['librabbitmq-dev']

--- a/catalog/extensions/apcu.yaml
+++ b/catalog/extensions/apcu.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
-  arch: ["x86_64"]
+  arch: ["x86_64", "aarch64"]
   ts: ["nts"]
 runtime_deps:
   linux: []

--- a/catalog/extensions/event.yaml
+++ b/catalog/extensions/event.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: ['libevent-dev', 'libssl-dev']

--- a/catalog/extensions/igbinary.yaml
+++ b/catalog/extensions/igbinary.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 exclude:
   # igbinary 3.2.16 references ext/standard/php_smart_string.h which was

--- a/catalog/extensions/memcached.yaml
+++ b/catalog/extensions/memcached.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: ['libmemcached-dev', 'libsasl2-dev', 'zlib1g-dev']

--- a/catalog/extensions/msgpack.yaml
+++ b/catalog/extensions/msgpack.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: []

--- a/catalog/extensions/pcov.yaml
+++ b/catalog/extensions/pcov.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
-  arch: ["x86_64"]
+  arch: ["x86_64", "aarch64"]
   ts: ["nts"]
 runtime_deps:
   linux: []

--- a/catalog/extensions/protobuf.yaml
+++ b/catalog/extensions/protobuf.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 exclude:
   - { php: '8.1' }

--- a/catalog/extensions/rdkafka.yaml
+++ b/catalog/extensions/rdkafka.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: ['librdkafka-dev']

--- a/catalog/extensions/redis.yaml
+++ b/catalog/extensions/redis.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
-  arch: ["x86_64"]
+  arch: ["x86_64", "aarch64"]
   ts: ["nts"]
 exclude:
   # redis 6.2.0 references ext/standard/php_smart_string.h which was removed

--- a/catalog/extensions/ssh2.yaml
+++ b/catalog/extensions/ssh2.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: ['libssh2-1-dev']

--- a/catalog/extensions/uuid.yaml
+++ b/catalog/extensions/uuid.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: ['uuid-dev']

--- a/catalog/extensions/xdebug.yaml
+++ b/catalog/extensions/xdebug.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
   os: ["linux"]
-  arch: ["x86_64"]
+  arch: ["x86_64", "aarch64"]
   ts: ["nts"]
 runtime_deps:
   linux: []

--- a/catalog/extensions/yaml.yaml
+++ b/catalog/extensions/yaml.yaml
@@ -7,7 +7,7 @@ versions:
 abi_matrix:
   php: ['8.1', '8.2', '8.3', '8.4', '8.5']
   os: ['linux']
-  arch: ['x86_64']
+  arch: ['x86_64', 'aarch64']
   ts: ['nts']
 build_deps:
   linux: ['libyaml-dev']

--- a/test/compat/fixtures.yaml
+++ b/test/compat/fixtures.yaml
@@ -350,3 +350,40 @@ fixtures:
     extensions: ''
     ini-values: ''
     coverage: 'none'
+
+  # 8.1 omits protobuf (PECL metadata min PHP 8.2).
+  - name: multi-ext-top14-arm64-81
+    php-version: '8.1'
+    arch: 'aarch64'
+    extensions: 'redis, xdebug, pcov, apcu, igbinary, msgpack, uuid, ssh2, yaml, memcached, amqp, event, rdkafka'
+    ini-values: ''
+    coverage: 'none'
+
+  - name: multi-ext-top14-arm64-82
+    php-version: '8.2'
+    arch: 'aarch64'
+    extensions: 'redis, xdebug, pcov, apcu, igbinary, msgpack, uuid, ssh2, yaml, memcached, amqp, event, rdkafka, protobuf'
+    ini-values: ''
+    coverage: 'none'
+
+  - name: multi-ext-top14-arm64-83
+    php-version: '8.3'
+    arch: 'aarch64'
+    extensions: 'redis, xdebug, pcov, apcu, igbinary, msgpack, uuid, ssh2, yaml, memcached, amqp, event, rdkafka, protobuf'
+    ini-values: ''
+    coverage: 'none'
+
+  - name: multi-ext-top14-arm64-84
+    php-version: '8.4'
+    arch: 'aarch64'
+    extensions: 'redis, xdebug, pcov, apcu, igbinary, msgpack, uuid, ssh2, yaml, memcached, amqp, event, rdkafka, protobuf'
+    ini-values: ''
+    coverage: 'none'
+
+  # 8.5 omits redis + igbinary (php_smart_string.h upstream issue; see #38, #43).
+  - name: multi-ext-top14-arm64-85
+    php-version: '8.5'
+    arch: 'aarch64'
+    extensions: 'xdebug, pcov, apcu, msgpack, uuid, ssh2, yaml, memcached, amqp, event, rdkafka, protobuf'
+    ini-values: ''
+    coverage: 'none'


### PR DESCRIPTION
## Summary

Slice C2a of Phase 2 aarch64 rollout. Enables the 14 easy+medium PECL extensions on linux/aarch64/nts:

- Slice-#1 four: `redis`, `xdebug`, `pcov`, `apcu`
- B1 ten: `igbinary`, `msgpack`, `uuid`, `ssh2`, `yaml`, `memcached`, `amqp`, `event`, `rdkafka`, `protobuf`

Hard tier (`imagick`, `mongodb`, `swoole`, `grpc`) deferred to C2b — mirrors the B1/B2 split so arm64-specific failures in the slow grpc / configure-surface-heavy extensions land in isolation.

Pure data slice. Inherits 100% of C1's scaffolding: workflow `runs-on` arch map, per-arch phpup build, `(version, arch)` fixture filter, `installRuntimeDeps`. No Go code, no builder script, no workflow changes.

## Carry-over excludes (arch-independent)

| Extension | Exclude | Reason |
|---|---|---|
| `redis` | `{ php: "8.5" }` | `php_smart_string.h` removed in 8.5 (source-level incompat, #38) |
| `igbinary` | `{ php: "8.5" }` | Same upstream issue (#43) |
| `protobuf` | `{ php: "8.1" }` | PECL metadata: `<min>8.2.0</min>` |

14 × 5 − 3 = 67 new arm64 ext bundles.

## Test plan

- [ ] CI: planner emits 67 new arm64 ext cells + 14 x86_64 refresh cells (spec-hash churn from abi_matrix change).
- [ ] CI: arm64 ext builds succeed with arch-uniform `runtime_deps.linux` packages (Ubuntu noble ships the same package names for both archs).
- [ ] CI: lockfile auto-commits 67 new entries.
- [ ] CI: 60 harness fixtures (55 existing + 5 new) pass with no new allowlist entries.
- [ ] CI: `make check` passes.

Spec: \`docs/superpowers/specs/2026-04-21-phase2-aarch64-c2a-design.md\`