### PR TITLE
feat: ubuntu-22.04 runner coverage (phase 2 slice D)

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   build:
     name: 'ext ${{ inputs.extension }} ${{ inputs.ext_version }} @ PHP ${{ inputs.php_abi }}'
-    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     permissions:
       packages: write
       id-token: write

--- a/.github/workflows/build-php-core.yml
+++ b/.github/workflows/build-php-core.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   build:
     name: 'core PHP ${{ inputs.version }} (${{ inputs.os }}/${{ inputs.arch }}/${{ inputs.ts }})'
-    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     permissions:
       packages: write
       id-token: write

--- a/.github/workflows/compat-harness.yml
+++ b/.github/workflows/compat-harness.yml
@@ -69,7 +69,7 @@ jobs:
   ours:
     name: 'ours: ${{ matrix.name }}'
     needs: [build, fixtures]
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'aarch64' && (matrix.runner_os == 'ubuntu-22.04' && 'ubuntu-22.04-arm' || 'ubuntu-24.04-arm') || (matrix.runner_os == 'ubuntu-22.04' && 'ubuntu-22.04' || 'ubuntu-24.04') }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.fixtures.outputs.matrix) }}
@@ -118,7 +118,7 @@ jobs:
   theirs:
     name: 'theirs: ${{ matrix.name }}'
     needs: [fixtures]
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'aarch64' && (matrix.runner_os == 'ubuntu-22.04' && 'ubuntu-22.04-arm' || 'ubuntu-24.04-arm') || (matrix.runner_os == 'ubuntu-22.04' && 'ubuntu-22.04' || 'ubuntu-24.04') }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.fixtures.outputs.matrix) }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Fast, reproducible PHP setup for GitHub Actions using prebuilt bundles.
 
-> **Status:** Alpha. Linux x86_64 only. PHP 8.1 – 8.5.
+> **Status:** Alpha. Linux x86_64 + aarch64 on Ubuntu 22.04 and Ubuntu 24.04. PHP 8.1 – 8.5.
+>
+> **Known gap:** `imagick` is compiled against ImageMagick 6 SOVERSION 6 (jammy's SONAME). On `ubuntu-24.04` runners, Ubuntu ships only SOVERSION 7 via `libmagickwand-6.q16-7t64`, so `imagick` will not load. Use `ubuntu-22.04` runners for `imagick`. Cross-OS support tracked in issue #NN.
 
 ## Quick Start
 
@@ -43,9 +45,9 @@ This means setup typically completes in single-digit seconds, and every run gets
 
 ## Supported Matrix
 
-| OS                   | Arch   | PHP | Thread Safety |
-| -------------------- | ------ | --- | ------------- |
-| Linux (Ubuntu 24.04) | x86_64 | 8.4 | NTS           |
+| OS                                  | Arch              | PHP       | Thread Safety |
+| ----------------------------------- | ----------------- | --------- | ------------- |
+| Linux (Ubuntu 22.04 and 24.04)      | x86_64 + aarch64  | 8.1 – 8.5 | NTS           |
 
 ### Bundled Extensions
 

--- a/builders/common/builder-os.env
+++ b/builders/common/builder-os.env
@@ -1,0 +1,6 @@
+# Pinned runner OS for PHP core and extension bundle builds.
+# Changing this value invalidates every spec_hash in bundles.lock and forces
+# a full bundle rebuild on the next pipeline run (see
+# internal/planner.ComputeSpecHash and
+# docs/superpowers/specs/2026-04-22-phase2-ubuntu-22.04-design.md).
+BUILDER_OS=ubuntu-22.04

--- a/catalog/extensions/event.yaml
+++ b/catalog/extensions/event.yaml
@@ -12,7 +12,7 @@ abi_matrix:
 build_deps:
   linux: ['libevent-dev', 'libssl-dev']
 runtime_deps:
-  linux: ['libevent-2.1-7t64', 'libevent-openssl-2.1-7t64']
+  linux: ['libevent-2.1-7', 'libevent-openssl-2.1-7']
 ini:
   - 'extension=event'
 smoke:

--- a/catalog/extensions/grpc.yaml
+++ b/catalog/extensions/grpc.yaml
@@ -12,7 +12,7 @@ abi_matrix:
 build_deps:
   linux: ['zlib1g-dev', 'libssl-dev']
 runtime_deps:
-  linux: ['libssl3t64']
+  linux: ['libssl3']
 ini:
   - 'extension=grpc'
 smoke:

--- a/catalog/extensions/imagick.yaml
+++ b/catalog/extensions/imagick.yaml
@@ -12,7 +12,7 @@ abi_matrix:
 build_deps:
   linux: ['libmagickwand-dev', 'libmagickcore-dev']
 runtime_deps:
-  linux: ['libmagickwand-6.q16-7t64', 'libmagickcore-6.q16-7t64']
+  linux: ['libmagickwand-6.q16-6', 'libmagickcore-6.q16-6']
 ini:
   - 'extension=imagick'
 smoke:

--- a/catalog/extensions/mongodb.yaml
+++ b/catalog/extensions/mongodb.yaml
@@ -12,7 +12,7 @@ abi_matrix:
 build_deps:
   linux: ['libssl-dev', 'libsasl2-dev']
 runtime_deps:
-  linux: ['libssl3t64', 'libsasl2-2']
+  linux: ['libssl3', 'libsasl2-2']
 ini:
   - 'extension=mongodb'
 smoke:

--- a/catalog/extensions/swoole.yaml
+++ b/catalog/extensions/swoole.yaml
@@ -15,7 +15,7 @@ exclude:
 build_deps:
   linux: ['libssl-dev', 'libcurl4-openssl-dev']
 runtime_deps:
-  linux: ['libssl3t64', 'libcurl4t64']
+  linux: ['libssl3', 'libcurl4']
 ini:
   - 'extension=swoole'
 smoke:

--- a/cmd/lockfile-update/main.go
+++ b/cmd/lockfile-update/main.go
@@ -69,6 +69,11 @@ func main() {
 	builderHashPHP = builderHashPHP + ":" + schemaEnvHash
 	builderHashExt = builderHashExt + ":" + schemaEnvHash
 
+	builderOS, err := planner.ReadBuilderOS(filepath.Join("builders", "common", "builder-os.env"))
+	if err != nil {
+		log.Fatalf("read builder OS: %v", err)
+	}
+
 	var resolved []resolvedEntry
 
 	// PHP core cells.
@@ -79,7 +84,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("per-version yaml %s: %v", c.Version, err)
 		}
-		c.SpecHash = planner.ComputeSpecHash(c, yamlBytes, builderHashPHP)
+		c.SpecHash = planner.ComputeSpecHash(c, yamlBytes, builderHashPHP, builderOS)
 
 		tag := fmt.Sprintf("%s-%s-%s-%s", c.Version, c.OS, c.Arch, c.TS)
 		ref := fmt.Sprintf("%s/php-core:%s", *registry, tag)
@@ -104,7 +109,7 @@ func main() {
 		cells := planner.ExpandExtMatrix(ext)
 		for i := range cells {
 			c := &cells[i]
-			c.SpecHash = planner.ComputeSpecHash(c, extYAML, builderHashExt)
+			c.SpecHash = planner.ComputeSpecHash(c, extYAML, builderHashExt, builderOS)
 
 			tag := fmt.Sprintf("%s-%s-%s-%s", c.ExtVer, c.PHPAbi, c.OS, c.Arch)
 			ref := fmt.Sprintf("%s/php-ext-%s:%s", *registry, c.Extension, tag)

--- a/cmd/phpup/main.go
+++ b/cmd/phpup/main.go
@@ -84,13 +84,13 @@ func main() {
 			"yaml":      {Name: "yaml", Kind: catalog.ExtensionKindPECL, Versions: []string{"2.3.0"}, RuntimeDeps: map[string][]string{"linux": {"libyaml-0-2"}}},
 			"memcached": {Name: "memcached", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.4.0"}, RuntimeDeps: map[string][]string{"linux": {"libmemcached11", "libsasl2-2"}}},
 			"amqp":      {Name: "amqp", Kind: catalog.ExtensionKindPECL, Versions: []string{"2.2.0"}, RuntimeDeps: map[string][]string{"linux": {"librabbitmq4"}}},
-			"event":     {Name: "event", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.1.4"}, RuntimeDeps: map[string][]string{"linux": {"libevent-2.1-7t64", "libevent-openssl-2.1-7t64"}}},
+			"event":     {Name: "event", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.1.4"}, RuntimeDeps: map[string][]string{"linux": {"libevent-2.1-7", "libevent-openssl-2.1-7"}}},
 			"rdkafka":   {Name: "rdkafka", Kind: catalog.ExtensionKindPECL, Versions: []string{"6.0.5"}, RuntimeDeps: map[string][]string{"linux": {"librdkafka1"}}},
 			"protobuf":  {Name: "protobuf", Kind: catalog.ExtensionKindPECL, Versions: []string{"5.34.1"}},
-			"imagick":   {Name: "imagick", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.8.1"}, RuntimeDeps: map[string][]string{"linux": {"libmagickwand-6.q16-7t64", "libmagickcore-6.q16-7t64"}}},
-			"mongodb":   {Name: "mongodb", Kind: catalog.ExtensionKindPECL, Versions: []string{"2.2.1"}, RuntimeDeps: map[string][]string{"linux": {"libssl3t64", "libsasl2-2"}}},
-			"swoole":    {Name: "swoole", Kind: catalog.ExtensionKindPECL, Versions: []string{"6.2.0"}, RuntimeDeps: map[string][]string{"linux": {"libssl3t64", "libcurl4t64"}}},
-			"grpc":      {Name: "grpc", Kind: catalog.ExtensionKindPECL, Versions: []string{"1.80.0"}, RuntimeDeps: map[string][]string{"linux": {"libssl3t64"}}},
+			"imagick":   {Name: "imagick", Kind: catalog.ExtensionKindPECL, Versions: []string{"3.8.1"}, RuntimeDeps: map[string][]string{"linux": {"libmagickwand-6.q16-6", "libmagickcore-6.q16-6"}}},
+			"mongodb":   {Name: "mongodb", Kind: catalog.ExtensionKindPECL, Versions: []string{"2.2.1"}, RuntimeDeps: map[string][]string{"linux": {"libssl3", "libsasl2-2"}}},
+			"swoole":    {Name: "swoole", Kind: catalog.ExtensionKindPECL, Versions: []string{"6.2.0"}, RuntimeDeps: map[string][]string{"linux": {"libssl3", "libcurl4"}}},
+			"grpc":      {Name: "grpc", Kind: catalog.ExtensionKindPECL, Versions: []string{"1.80.0"}, RuntimeDeps: map[string][]string{"linux": {"libssl3"}}},
 		},
 	}
 

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -62,6 +62,11 @@ func main() {
 	builderHashPHP = builderHashPHP + ":" + schemaEnvHash
 	builderHashExt = builderHashExt + ":" + schemaEnvHash
 
+	builderOS, err := planner.ReadBuilderOS(filepath.Join("builders", "common", "builder-os.env"))
+	if err != nil {
+		log.Fatalf("read builder OS: %v", err)
+	}
+
 	// Expand PHP matrix
 	phpCells := planner.ExpandPHPMatrix(cat.PHP)
 	for i := range phpCells {
@@ -69,7 +74,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("per-version yaml for %s: %v", phpCells[i].Version, err)
 		}
-		phpCells[i].SpecHash = planner.ComputeSpecHash(&phpCells[i], yamlBytes, builderHashPHP)
+		phpCells[i].SpecHash = planner.ComputeSpecHash(&phpCells[i], yamlBytes, builderHashPHP, builderOS)
 	}
 
 	if !*force {
@@ -89,7 +94,7 @@ func main() {
 			log.Fatalf("ext yaml for %s: %v", ext.Name, err)
 		}
 		for i := range cells {
-			cells[i].SpecHash = planner.ComputeSpecHash(&cells[i], extYAML, builderHashExt)
+			cells[i].SpecHash = planner.ComputeSpecHash(&cells[i], extYAML, builderHashExt, builderOS)
 		}
 		if !*force {
 			cells = filterExisting(ctx, cells, lf, client)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -110,10 +111,16 @@ func isExcluded(rules []catalog.ExcludeRule, osName, arch, php string) bool {
 }
 
 // ComputeSpecHash computes a deterministic hash for a matrix cell.
-func ComputeSpecHash(cell *MatrixCell, catalogData []byte, builderHash string) string {
+// builderOS is the pinned builder runner OS (e.g. "ubuntu-22.04"), read from
+// builders/common/builder-os.env by the caller. Including it here means a
+// runner-OS change invalidates every cell's spec_hash and forces the pipeline
+// to rebuild every bundle on the new OS, guaranteeing the lockfile and the
+// physical bundles stay in sync.
+func ComputeSpecHash(cell *MatrixCell, catalogData []byte, builderHash, builderOS string) string {
 	h := sha256.New()
 	h.Write(catalogData)
 	h.Write([]byte(builderHash))
+	h.Write([]byte(builderOS))
 	_, _ = fmt.Fprintf(h, "%s:%s:%s:%s:%s:%s",
 		cell.Version, cell.Extension, cell.OS, cell.Arch, cell.TS, cell.PHPAbi)
 	return fmt.Sprintf("sha256:%x", h.Sum(nil))
@@ -129,6 +136,32 @@ func HashFile(path string) (string, error) {
 	}
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("sha256:%x", sum[:]), nil
+}
+
+// ReadBuilderOS reads the pinned BUILDER_OS value from
+// builders/common/builder-os.env. The file format is one or more VAR=value
+// lines; only the BUILDER_OS key is consulted. Missing file or missing key
+// produces a clear error so callers can bail early with a recognisable
+// diagnostic (matches the HashFile missing-file contract).
+func ReadBuilderOS(path string) (string, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("read builder-os env %s: %w", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == "BUILDER_OS" {
+			return strings.TrimSpace(value), nil
+		}
+	}
+	return "", fmt.Errorf("BUILDER_OS not set in %s", path)
 }
 
 // PerVersionYAML marshals a single version entry from a PHP spec into

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -125,12 +125,12 @@ func TestExpandExtMatrixWithExclude(t *testing.T) {
 
 func TestComputeSpecHash(t *testing.T) {
 	cell := MatrixCell{Version: "8.4", OS: "linux", Arch: "x86_64", TS: "nts"}
-	h1 := ComputeSpecHash(&cell, []byte("catalog data"), "builder-hash-1")
-	h2 := ComputeSpecHash(&cell, []byte("catalog data"), "builder-hash-1")
+	h1 := ComputeSpecHash(&cell, []byte("catalog data"), "builder-hash-1", "ubuntu-22.04")
+	h2 := ComputeSpecHash(&cell, []byte("catalog data"), "builder-hash-1", "ubuntu-22.04")
 	if h1 != h2 {
 		t.Error("ComputeSpecHash should be deterministic")
 	}
-	h3 := ComputeSpecHash(&cell, []byte("different catalog"), "builder-hash-1")
+	h3 := ComputeSpecHash(&cell, []byte("different catalog"), "builder-hash-1", "ubuntu-22.04")
 	if h1 == h3 {
 		t.Error("ComputeSpecHash should differ for different inputs")
 	}
@@ -241,20 +241,81 @@ func TestExtensionYAMLDeterminism(t *testing.T) {
 
 func TestComputeSpecHashDeltas(t *testing.T) {
 	cell := MatrixCell{Version: "8.4", OS: "linux", Arch: "x86_64", TS: "nts"}
-	base := ComputeSpecHash(&cell, []byte("catalog"), "builder-a")
+	base := ComputeSpecHash(&cell, []byte("catalog"), "builder-a", "ubuntu-22.04")
 
-	if got := ComputeSpecHash(&cell, []byte("catalog"), "builder-a"); got != base {
+	if got := ComputeSpecHash(&cell, []byte("catalog"), "builder-a", "ubuntu-22.04"); got != base {
 		t.Error("same inputs must produce same hash")
 	}
-	if got := ComputeSpecHash(&cell, []byte("catalog-v2"), "builder-a"); got == base {
+	if got := ComputeSpecHash(&cell, []byte("catalog-v2"), "builder-a", "ubuntu-22.04"); got == base {
 		t.Error("changing catalog must change hash")
 	}
-	if got := ComputeSpecHash(&cell, []byte("catalog"), "builder-b"); got == base {
+	if got := ComputeSpecHash(&cell, []byte("catalog"), "builder-b", "ubuntu-22.04"); got == base {
 		t.Error("changing builder must change hash")
 	}
 	cell2 := cell
 	cell2.Version = "8.5"
-	if got := ComputeSpecHash(&cell2, []byte("catalog"), "builder-a"); got == base {
+	if got := ComputeSpecHash(&cell2, []byte("catalog"), "builder-a", "ubuntu-22.04"); got == base {
 		t.Error("changing cell must change hash")
+	}
+}
+
+func TestComputeSpecHash_BuilderOSIsLoadBearing(t *testing.T) {
+	cell := &MatrixCell{
+		Version: "8.4", OS: "linux", Arch: "x86_64", TS: "nts", PHPAbi: "8.4-nts",
+	}
+	catalogData := []byte("name: php\nversions: {}\n")
+	builderHash := "sha256:deadbeef"
+
+	h1 := ComputeSpecHash(cell, catalogData, builderHash, "ubuntu-22.04")
+	h2 := ComputeSpecHash(cell, catalogData, builderHash, "ubuntu-24.04")
+
+	if h1 == h2 {
+		t.Errorf("expected different hashes for different BUILDER_OS; both = %q", h1)
+	}
+}
+
+func TestComputeSpecHash_BuilderOSStableForSameValue(t *testing.T) {
+	cell := &MatrixCell{
+		Version: "8.4", OS: "linux", Arch: "x86_64", TS: "nts", PHPAbi: "8.4-nts",
+	}
+	catalogData := []byte("name: php\n")
+	builderHash := "sha256:cafebabe"
+
+	h1 := ComputeSpecHash(cell, catalogData, builderHash, "ubuntu-22.04")
+	h2 := ComputeSpecHash(cell, catalogData, builderHash, "ubuntu-22.04")
+
+	if h1 != h2 {
+		t.Errorf("expected stable hash for same BUILDER_OS; got %q vs %q", h1, h2)
+	}
+}
+
+func TestReadBuilderOS(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "builder-os.env")
+
+	// Valid file
+	if err := os.WriteFile(path, []byte("# comment\nBUILDER_OS=ubuntu-22.04\n"), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+	got, err := ReadBuilderOS(path)
+	if err != nil {
+		t.Fatalf("ReadBuilderOS: %v", err)
+	}
+	if got != "ubuntu-22.04" {
+		t.Errorf("ReadBuilderOS = %q, want %q", got, "ubuntu-22.04")
+	}
+
+	// Missing file
+	if _, err := ReadBuilderOS(filepath.Join(dir, "nonexistent.env")); err == nil {
+		t.Error("expected error for missing file")
+	}
+
+	// File without BUILDER_OS key
+	other := filepath.Join(dir, "other.env")
+	if err := os.WriteFile(other, []byte("OTHER_VAR=x\n"), 0o600); err != nil {
+		t.Fatalf("write other env: %v", err)
+	}
+	if _, err := ReadBuilderOS(other); err == nil {
+		t.Error("expected error for file without BUILDER_OS")
 	}
 }

--- a/test/compat/fixtures.yaml
+++ b/test/compat/fixtures.yaml
@@ -424,3 +424,42 @@ fixtures:
     extensions: 'imagick, mongodb, swoole, grpc'
     ini-values: ''
     coverage: 'none'
+
+  # bare fixtures on ubuntu-22.04 prove that jammy-built bundles load on
+  # jammy runners (slice D moves the builder from noble → jammy).
+  # x86_64 only for now; arm64-jammy is a potential follow-up if drift
+  # surfaces beyond what glibc forward-compat + transitional packages cover.
+  - name: bare-jammy-81
+    php-version: '8.1'
+    runner_os: 'ubuntu-22.04'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-jammy-82
+    php-version: '8.2'
+    runner_os: 'ubuntu-22.04'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-jammy-83
+    php-version: '8.3'
+    runner_os: 'ubuntu-22.04'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-jammy-84
+    php-version: '8.4'
+    runner_os: 'ubuntu-22.04'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'
+
+  - name: bare-jammy-85
+    php-version: '8.5'
+    runner_os: 'ubuntu-22.04'
+    extensions: ''
+    ini-values: ''
+    coverage: 'none'


### PR DESCRIPTION
## Summary

Final Phase-2 slice. Moves the builder runner from \`ubuntu-24.04\` (noble) to \`ubuntu-22.04\` (jammy) so compiled bundles run on both OS releases via glibc forward-compat. Forces a full rebuild of all 182 bundles by folding \`BUILDER_OS\` into \`ComputeSpecHash\`.

## What lands

- \`builders/common/builder-os.env\` pins \`BUILDER_OS=ubuntu-22.04\`.
- \`internal/planner.ComputeSpecHash\` gains \`builderOS\` parameter; every spec_hash now depends on it.
- \`build-php-core.yml\` + \`build-extension.yml\` dispatch to \`ubuntu-22.04\` / \`ubuntu-22.04-arm\`.
- \`runtime_deps.linux\` rewritten to jammy-native package names (drop \`-t64\` suffixes).
- \`compat-harness.yml\` gains \`runner_os\` fixture dimension + 5 \`bare-jammy-<NN>\` fixtures (x86_64 only).
- README: supported runners + imagick-on-noble known gap.

## Known gap — imagick on noble

imagick compiles against \`libMagickWand-6.Q16.so.6\` (jammy's SOVERSION). Noble ships SOVERSION 7 via \`libmagickwand-6.q16-7t64\` — no transitional back-port. Users on \`ubuntu-24.04\` runners who request \`extensions: imagick\` hit a clear apt-install failure. Tracked in a follow-up issue (to be filed post-merge).

## Test plan

- [ ] CI: planner emits all 182 cells (every spec_hash changed from \`BUILDER_OS\` addition).
- [ ] CI: 182 jammy rebuilds succeed; wall-clock dominated by 10 × grpc ≈ 45–60 min.
- [ ] CI: lockfile auto-commits 182 refreshed digests.
- [ ] CI: 70 harness fixtures (65 noble + 5 jammy) pass with no new allowlist beyond existing bands.
- [ ] CI: \`make check\` passes.

Spec: \`docs/superpowers/specs/2026-04-22-phase2-ubuntu-22.04-design.md\`