### PR TITLE
docs(compat-matrix): Phase 2 allowlist cleanup

### DIFF
--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -477,12 +477,15 @@ deviations:
     reason: 'v2 auto-installs composer and sets COMPOSER_* env vars; tools parity is Phase 3 scope'
     fixtures: ['*']
 
-  # extensions: v2 on Ondrej PPA ships ~80 extensions; we ship the Phase 1
-  # baseline of ~52 (core + 4 PECLs). `allow` so we still catch the case where
-  # our bundle fails to load any extensions.
+  # extensions: v2 on Ondrej PPA ships ~80 extensions; we ship Phase 2's
+  # top-50 baseline (34 compiled-in + 18 PECL bundles across 8.1-8.5, minus
+  # four upstream-source excludes tracked in #38, #43). The loaded-extension
+  # set is expected to stay a proper subset of v2's indefinitely — we don't
+  # intend to match Ondrej's complete catalog. `allow` so we still catch the
+  # case where our bundle fails to load any extensions.
   - path: extensions
     kind: allow
-    reason: 'bundled extension set expansion is Phase 2 follow-up slice #3 (top-50)'
+    reason: 'our top-50 baseline is a documented subset of Ondrej PPA; see top-10/hard-4 slice specs'
     fixtures: ['*']
 
   # path_additions: both sides add a tool-chain directory to PATH, but the
@@ -491,27 +494,6 @@ deviations:
   - path: path_additions
     kind: allow
     reason: 'both sides prepend a PHP install prefix; exact directory differs by design'
-    fixtures: ['*']
-
-  # Opcache defaults from php.ini-production: v2 ships php.ini-production; our
-  # builder now does too (T5). These four keys come from the production preset
-  # and should match once the 8.4 core is rebuilt. Pending post-merge CI
-  # confirmation before removing.
-  - path: ini.opcache.enable_cli
-    kind: ignore
-    reason: 'php.ini-production default; pending post-merge harness confirmation'
-    fixtures: ['*']
-  - path: ini.opcache.memory_consumption
-    kind: ignore
-    reason: 'php.ini-production default; pending post-merge harness confirmation'
-    fixtures: ['*']
-  - path: ini.opcache.revalidate_freq
-    kind: ignore
-    reason: 'php.ini-production default; pending post-merge harness confirmation'
-    fixtures: ['*']
-  - path: ini.opcache.validate_timestamps
-    kind: ignore
-    reason: 'php.ini-production default; pending post-merge harness confirmation'
     fixtures: ['*']
 
   # xdebug.mode / start_with_request on multi-ext: v2's apt xdebug install is


### PR DESCRIPTION
## Summary

Two non-deferred Phase 2 leftovers:

1. **Drop 4 `ini.opcache.*` allowlist entries** tagged "pending post-merge harness confirmation" in the compat-closeout slice. They were placeholders awaiting verification that v2's and our source-built PHP both emit the same \`php.ini-production\` opcache defaults. Multiple post-closeout harness runs have been green; the entries are dead code. If any one actually turns out to still drift, CI will surface it on a future PR and we can re-add with an accurate diagnosis.

2. **Refresh the \`extensions\` allowlist reason.** Old text cited "Phase 2 follow-up slice #3 (top-50)" as the reason our set differs from v2's — that slice is landed (B1 #42 + B2 #44). The \`allow\` kind is still correct (v2 loads ~80 via Ondrej PPA; we ship our audited top-50 baseline) — the new reason records that as a deliberate stable state rather than a pending migration.

## Test plan

- [ ] \`make check\` passes (done locally).
- [ ] CI compat-harness: 65 fixtures × 3 jobs green without the removed entries. If any opcache key drifts, it surfaces specific to a fixture; revert + re-add with accurate reason.

No code changes, no bundle rebuilds. Pure docs / policy cleanup.