### PR TITLE
feat(ci): re-enable PHP 8.5 in pipeline matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,7 @@ jobs:
       matrix:
         os:   [jammy, noble]
         arch: [x86_64, aarch64]
-        # NOTE: PHP 8.5 omitted pending a builder fix — capture-hermetic-libs
-        # reports "php has no DT_RUNPATH/DT_RPATH" after compile, meaning
-        # builders/linux/build-php.sh's patchelf step doesn't land on 8.5
-        # binaries. Pre-existing issue, not introduced by this PR; tracked
-        # as follow-up. Add "8.5" back once the builder applies rpath.
-        php:  ["8.1", "8.2", "8.3", "8.4"]
+        php:  ["8.1", "8.2", "8.3", "8.4", "8.5"]
     runs-on: >-
       ${{ matrix.arch == 'aarch64'
           && (matrix.os == 'jammy' && 'ubuntu-22.04-arm' || 'ubuntu-24.04-arm')

--- a/builders/linux/build-ext.sh
+++ b/builders/linux/build-ext.sh
@@ -50,7 +50,7 @@ export PATH="/usr/local/bin:$PATH"
 # Download extension source from PECL
 PECL_URL="https://pecl.php.net/get/${EXT_NAME}-${EXT_VERSION}.tgz"
 echo "Downloading ${PECL_URL}"
-curl -sSfL -o /tmp/ext.tgz "$PECL_URL"
+curl -sSfL --retry 5 --retry-delay 2 -o /tmp/ext.tgz "$PECL_URL"
 
 # Extract
 mkdir -p /tmp/ext-src
@@ -92,7 +92,7 @@ patchelf --set-rpath '$ORIGIN/hermetic' "$SO_FILE"
 echo "Extension ${EXT_NAME}.so built at ${SO_FILE}"
 
 if ! command -v yq >/dev/null 2>&1; then
-    curl -sSfL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)
+    curl -sSfL --retry 5 --retry-delay 2 -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)
     chmod +x /usr/local/bin/yq
 fi
 

--- a/builders/linux/build-php.sh
+++ b/builders/linux/build-php.sh
@@ -13,7 +13,7 @@ PHP_SRC_DIR="${PHP_SRC_DIR:-/tmp/php-src}"
 
 # Resolve minor version (e.g. "8.4") to latest patch version (e.g. "8.4.20")
 if [[ "$PHP_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-  RESOLVED=$(curl -sSf "https://www.php.net/releases/index.php?json&version=${PHP_VERSION}" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4)
+  RESOLVED=$(curl -sSf --retry 5 --retry-delay 2 "https://www.php.net/releases/index.php?json&version=${PHP_VERSION}" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4)
   if [ -z "$RESOLVED" ]; then
     echo "Error: could not resolve PHP ${PHP_VERSION} to a patch version"
     exit 1
@@ -62,7 +62,7 @@ echo "::endgroup::"
 # Download PHP source
 PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz"
 echo "Downloading ${PHP_URL}"
-curl -sSfL -o /tmp/php.tar.xz "$PHP_URL"
+curl -sSfL --retry 5 --retry-delay 2 -o /tmp/php.tar.xz "$PHP_URL"
 
 # Extract source
 mkdir -p "$PHP_SRC_DIR"
@@ -155,7 +155,7 @@ echo "PHP ${PHP_VERSION} built successfully"
 
 # Ensure yq is present (GitHub runners ship it; local Docker image may not).
 if ! command -v yq >/dev/null 2>&1; then
-    curl -sSfL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)
+    curl -sSfL --retry 5 --retry-delay 2 -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)
     chmod +x /usr/local/bin/yq
 fi
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -38,7 +38,11 @@ const LinuxAptPreamble = "apt-get update && " +
 	// Arch detection: uname -m on linux returns x86_64 or aarch64; oras
 	// releases use amd64/arm64. One shell line keeps the preamble terse.
 	"ARCH_ORAS=$(uname -m); case \"$ARCH_ORAS\" in x86_64) ORAS_ARCH=amd64 ;; aarch64) ORAS_ARCH=arm64 ;; esac; " +
-	"curl -sSfL https://github.com/oras-project/oras/releases/download/v" + orasVersion +
+	// GitHub releases CDN occasionally 502s transiently. curl's --retry
+	// covers 408/429/5xx + timeouts; 5 attempts × 2s delay ≈ 30s of
+	// resilience before giving up, enough to ride out a brief outage
+	// without letting a flaky hop fail the whole pipeline cell.
+	"curl -sSfL --retry 5 --retry-delay 2 https://github.com/oras-project/oras/releases/download/v" + orasVersion +
 	"/oras_" + orasVersion + "_linux_${ORAS_ARCH}.tar.gz | tar -xz -C /usr/local/bin oras && "
 
 // LinuxExtAptPreamble extends LinuxAptPreamble with PHP's runtime shared-


### PR DESCRIPTION
## Summary

Closes out Phase 2 by re-enabling PHP 8.5 in the `ci.yml::pipeline` matrix. The omission note added in PR 4 claimed the builder's patchelf step didn't land on 8.5 binaries (capture-hermetic-libs reporting "php has no DT_RUNPATH/DT_RPATH"). That no longer reproduces:

- Local `make bundle-php PHP_VERSION=8.5 OS=jammy ARCH=aarch64` sets DT_RUNPATH=`$ORIGIN/../lib/hermetic:$ORIGIN/../lib` correctly (verified via `readelf -d`).
- Local `make ci-cell OS=jammy ARCH=aarch64 PHP=8.5` runs green end-to-end: php-core + all 17 extensions build, all 3 fixtures pass.

Either the earlier failure was intermittent or one of the intervening changes (the `event`-ext `libevent-extra-2.1-7` runtime-dep fix, the `ci.yml` libicu codename select, or the cross-OS hermetic-libs work) absorbed it. Catalog is already 8.5-ready — every PECL ext declares `"8.5"` in its `abi_matrix.php`.

Matrix grows 16 → 20 cells.

## Test plan

- [x] Local `readelf -d /usr/local/bin/php` shows `DT_RUNPATH` after build
- [x] Local `make ci-cell OS=jammy ARCH=aarch64 PHP=8.5` — 3/3 fixtures pass
- [ ] CI `ci.yml` pipeline runs 20 cells green on this PR (validates jammy/x86_64, noble/x86_64, noble/aarch64 which weren't reproduced locally)