### PR TITLE
feat(ci): smoke-test the action surface on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,76 @@ jobs:
           path: out/oci-layout
           retention-days: 7
 
+  smoke-action:
+    name: "Smoke action surface (${{ matrix.os }}/${{ matrix.arch }})"
+    needs: pipeline
+    # Exercises the public action.yml + src/index.js wrapper end-to-end
+    # the way a user's `uses: buildrush/setup-php@v1` would, against the
+    # PR's HEAD binary. `runMain()` in src/index.js short-circuits the
+    # GitHub-release download when the expected cache path already
+    # contains a binary — so we build phpup from the PR and drop it at
+    # that exact path *before* invoking `uses: ./`.
+    #
+    # Matrix is deliberately narrower than `pipeline` (which covers 20
+    # OS/arch/PHP combos at the CLI level): the wrapper itself is thin
+    # and OS-invariant, so 2 OS × 2 arch × 1 PHP catches wrapper
+    # regressions without multiplying CI time.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: jammy
+            arch: amd64
+            runner: ubuntu-22.04
+          - os: noble
+            arch: amd64
+            runner: ubuntu-24.04
+          - os: jammy
+            arch: arm64
+            runner: ubuntu-22.04-arm
+          - os: noble
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Prepare embedded lockfile
+        run: cp bundles.lock cmd/phpup/bundles.lock
+      - name: Build phpup from PR HEAD into the runner cache
+        # src/index.js:runMain() resolves its cached binary path as
+        # $RUNNER_TOOL_CACHE/buildrush-bin/phpup (linux) and skips the
+        # release-asset download when existsSync() returns true. That's
+        # the hook we use to run the wrapper against *this PR's* phpup
+        # binary rather than whatever the latest release carries.
+        run: |
+          mkdir -p "$RUNNER_TOOL_CACHE/buildrush-bin"
+          go build -o "$RUNNER_TOOL_CACHE/buildrush-bin/phpup" ./cmd/phpup
+          chmod +x "$RUNNER_TOOL_CACHE/buildrush-bin/phpup"
+      - name: Invoke action (uses ./)
+        uses: ./
+        with:
+          php-version: "8.4"
+          extensions: "redis, intl"
+          ini-values: "memory_limit=256M"
+      - name: Assert PHP is installed + inputs honored
+        run: |
+          set -euo pipefail
+          php -v
+          php -r 'exit(extension_loaded("redis") ? 0 : 1);' \
+            || { echo "::error::redis extension not loaded"; exit 1; }
+          php -r 'exit(extension_loaded("intl") ? 0 : 1);' \
+            || { echo "::error::intl extension not loaded"; exit 1; }
+          memlim=$(php -r 'echo ini_get("memory_limit");')
+          test "$memlim" = "256M" \
+            || { echo "::error::memory_limit=$memlim, want 256M"; exit 1; }
+          echo "smoke-action: action surface OK"
+
   publish:
     name: Publish to GHCR
-    needs: pipeline
+    needs: [pipeline, smoke-action]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary

Closes the primary gap surfaced by the post-unification pipeline audit: **the public action surface (`action.yml` + `src/index.js`) has no PR-gated test**. Today, a PR that breaks the composite-action glue — typo in an `action.yml` input, regression in `src/index.js`'s input parsing — passes all 22 CI jobs and still ships a broken action.

This PR adds a 4-cell `smoke-action` matrix that invokes the wrapper end-to-end the way a consumer does.

## How it runs the PR's phpup, not a released one

`src/index.js:runMain()` checks `existsSync($RUNNER_TOOL_CACHE/buildrush-bin/phpup)` before hitting the network (line 165). If that path exists, it uses the binary and skips both `resolveReleaseTag` and `downloadFile`.

The new job builds phpup from PR HEAD directly into that cache path, then does `uses: ./`. End-to-end: PR's `action.yml` → PR's `src/index.js` → PR's phpup binary. **Zero changes to `src/index.js`** — the existing cache-hit path is the right hook.

## Matrix

| OS | arch | runner | PHP |
|---|---|---|---|
| jammy | amd64 | ubuntu-22.04 | 8.4 |
| noble | amd64 | ubuntu-24.04 | 8.4 |
| jammy | arm64 | ubuntu-22.04-arm | 8.4 |
| noble | arm64 | ubuntu-24.04-arm | 8.4 |

Deliberately narrower than `pipeline` (20 cells): the wrapper is OS-invariant and arch-variant; 4 cells catch wrapper regressions without multiplying CI time.

## Assertions per cell

- `php -v` succeeds (smoke)
- `extension_loaded("redis")` + `extension_loaded("intl")` (extensions input honored)
- `ini_get("memory_limit") == "256M"` (ini-values input honored)

## Wiring

- `smoke-action: needs: pipeline` — fails fast if the CLI side broke.
- `publish: needs: [pipeline, smoke-action]` — a broken wrapper on main would otherwise publish a bundle the action can't use.

## What's deferred to a follow-up PR

v2 drop-in compat (diff against `shivammathur/setup-php@v2`, using `docs/compat-matrix.md` allowlist) — the coverage lost when `compat-harness.yml` was deleted in PR #60. Keeping this PR small and easy to revert; v2 compat gets its own PR once `smoke-action` is proven stable.

## Test plan

- [x] `make check` green locally
- [ ] CI green on this PR (all 4 `smoke-action` cells + the existing 22 jobs)
- [ ] After merge: break an `action.yml` input name on a throwaway branch; confirm `smoke-action` goes red where it would previously have been green