### PR TITLE
ci: smoke-action PR self-containment (closes #83)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,9 @@ jobs:
           # "do the normal cache-probe".
           FORCE: ${{ inputs.force && '1' || '' }}
         run: make ci-cell OS=${{ matrix.os }} ARCH=${{ matrix.arch }} PHP=${{ matrix.php }} FORCE="$FORCE"
-      - name: Upload oci-layout artifact (main only)
-        if: github.ref == 'refs/heads/main'
+      - name: Upload oci-layout artifact
+        # Uploaded on every run (PR and main). PR runs use it for
+        # smoke-action self-containment; main runs feed publish.
         uses: actions/upload-artifact@v7
         with:
           name: oci-layout-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.php }}
@@ -169,7 +170,42 @@ jobs:
           mkdir -p "$RUNNER_TOOL_CACHE/buildrush-bin"
           go build -o "$RUNNER_TOOL_CACHE/buildrush-bin/phpup" ./cmd/phpup
           chmod +x "$RUNNER_TOOL_CACHE/buildrush-bin/phpup"
+      - name: Translate arch label for artifact lookup
+        # pipeline matrix uses x86_64/aarch64; smoke matrix uses amd64/arm64.
+        # Compute the pipeline-style arch for the download-artifact name.
+        id: archlabel
+        run: |
+          case "${{ matrix.arch }}" in
+            amd64) echo "value=x86_64"  >> "$GITHUB_OUTPUT" ;;
+            arm64) echo "value=aarch64" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::unknown matrix.arch=${{ matrix.arch }}"; exit 2 ;;
+          esac
+      - name: Download pipeline oci-layout for this cell
+        # PHP 8.4 hardcoded — the smoke matrix is fixed at 8.4 (see comment
+        # on the matrix definition above). Keep the version aligned with the
+        # `php-version:` input passed to `uses: ./` below.
+        uses: actions/download-artifact@v8
+        with:
+          name: oci-layout-${{ matrix.os }}-${{ steps.archlabel.outputs.value }}-8.4
+          path: out/oci-layout
+      - name: Synthesize PR-local lockfile from layout
+        # Resolves bundle keys against the just-built layout's digests rather
+        # than the (possibly stale) committed bundles.lock + GHCR. The action
+        # invocation below picks this up via PHPUP_REGISTRY/PHPUP_LOCKFILE.
+        run: |
+          "$RUNNER_TOOL_CACHE/buildrush-bin/phpup" internal lockfile-from-layout \
+            --layout "oci-layout:$PWD/out/oci-layout" \
+            --out "$RUNNER_TEMP/bundles-override.lock"
       - name: Invoke action (uses ./)
+        env:
+          # Point phpup install at the PR-local oci-layout + synthesized
+          # lockfile so smoke validates the public action surface end-to-end
+          # against the bundles this PR's pipeline actually built. Without
+          # these env overrides, phpup install would query the committed
+          # bundles.lock + GHCR — which lags behind any PR that bumps a
+          # bundle version and causes a deadlock with the `publish` job.
+          PHPUP_REGISTRY: oci-layout:${{ github.workspace }}/out/oci-layout
+          PHPUP_LOCKFILE: ${{ runner.temp }}/bundles-override.lock
         uses: ./
         with:
           php-version: "8.4"

--- a/docs/superpowers/specs/2026-04-27-smoke-action-pr-self-containment-design.md
+++ b/docs/superpowers/specs/2026-04-27-smoke-action-pr-self-containment-design.md
@@ -1,0 +1,124 @@
+# smoke-action PR self-containment
+
+**Issue:** [#83](https://github.com/buildrush/setup-php/issues/83)
+**Status:** Design approved 2026-04-27
+**Triggered by:** PR #76 (redis 6.3.0) deadlocked on `smoke-action` because it resolves bundles via the committed `bundles.lock` + GHCR, and `publish` is gated on `smoke-action` succeeding — so version-bumping PRs deadlock the lockfile-update flow on main.
+
+## 1. Goal & scope
+
+Make `smoke-action` consume the OCI layouts the `pipeline` job builds in the same CI run, so PRs that change bundle content (PECL version bumps, configure-flag changes, schema-version bumps) can validate the public action surface end-to-end without depending on GHCR.
+
+This realigns the implementation with the PR self-containment design from `docs/superpowers/specs/2026-04-23-local-ci-unification-design.md` ("No cross-job GHCR roundtrip — A pipeline cell builds PHP-core → builds extensions → runs fixtures against the just-built artifacts in *its own* OCI layout. GHCR is touched only by the `publish` job after the full matrix passes on `main`.") and `2026-04-20-bundle-schema-and-rollout-design.md` ("PR CI produces a self-consistent artifact set: every runtime assertion the PR introduces is validated against a bundle that the PR itself published.").
+
+### In scope
+
+- Drop the `if: github.ref == 'refs/heads/main'` gate on `pipeline.Upload oci-layout artifact` so PR runs upload per-cell layouts.
+- New `phpup internal lockfile-from-layout` subcommand wrapping the existing `internal/testsuite/runner.go:writeLayoutLockfileOverride` logic.
+- `smoke-action` downloads the matching cell's oci-layout artifact, synthesizes a lockfile override, sets `PHPUP_REGISTRY=oci-layout:<path>` and `PHPUP_LOCKFILE=<override>` for the `uses: ./` action invocation.
+
+### Out of scope
+
+- Promoting PR-local bundles to GHCR. The `publish` job remains main-only — that's intended.
+- Changing the `smoke-action` matrix shape or `pipeline` test execution (already self-contained).
+- Re-landing redis 6.3.0 — separate slice that resumes once this lands and unblocks the lockfile flow.
+
+## 2. Architecture
+
+Three components, one cohesive change.
+
+### 2.1 Artifact upload on PRs (CI workflow)
+
+**File:** `.github/workflows/ci.yml`
+
+Drop the conditional on the artifact upload step. The `actions/upload-artifact@v7` step keeps `retention-days: 7` so PR storage cost is bounded. Each pipeline cell uploads `oci-layout-<os>-<arch>-<php>` regardless of branch.
+
+```yaml
+- name: Upload oci-layout artifact
+  uses: actions/upload-artifact@v7
+  with:
+    name: oci-layout-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.php }}
+    path: out/oci-layout
+    retention-days: 7
+```
+
+(Was: `if: github.ref == 'refs/heads/main'` — removed.)
+
+### 2.2 `phpup internal lockfile-from-layout` subcommand (Go)
+
+**File:** new file `internal/lockfilefromlayout/lockfilefromlayout.go`. Hooks into the existing `phpup internal <subcmd>` dispatcher in `cmd/phpup/main.go` (currently routes to `testsuite.InternalMain`).
+
+The subcommand is a thin wrapper over `internal/testsuite/runner.go:writeLayoutLockfileOverride`. To avoid coupling the testsuite package to the new subcommand, factor the logic into a shared package: extract `writeLayoutLockfileOverride` into a new exported function in a new package `internal/layoutlockfile`, leave a one-line shim in testsuite that calls it. The new subcommand is then a 30-line CLI wrapper.
+
+```
+phpup internal lockfile-from-layout \
+  --layout oci-layout:./out/merged-layout \
+  --out ./bundles-override.lock
+```
+
+Behavior: walks the layout's annotated manifests, maps each `io.buildrush.bundle.key` annotation to its digest + spec_hash, writes a v2 lockfile JSON to `--out`. Identical schema to the existing override the testsuite synthesizes — same field shapes, same `schema_version: 2`.
+
+Failure modes are explicit: missing layout → `layout: open: <err>`, no manifests → empty lockfile (not an error — caller decides). No GHCR network calls.
+
+### 2.3 `smoke-action` consumes the artifact (CI workflow)
+
+**File:** `.github/workflows/ci.yml`
+
+Add four steps before `Invoke action (uses ./)`:
+
+1. `actions/download-artifact@v8` for `oci-layout-${{ matrix.os }}-${{ matrix.arch }}-8.4` into `out/oci-layout`.
+2. Build phpup (already happening in the existing "Build phpup from PR HEAD" step — reuse its output).
+3. Run `phpup internal lockfile-from-layout --layout oci-layout:$PWD/out/oci-layout --out $RUNNER_TEMP/bundles-override.lock`.
+4. Set step-level `env` on the `uses: ./` step: `PHPUP_REGISTRY: oci-layout:$PWD/out/oci-layout` and `PHPUP_LOCKFILE: $RUNNER_TEMP/bundles-override.lock`.
+
+The `uses: ./` step then runs the action wrapper. `src/index.js` invokes phpup, which honors both env overrides (already implemented at `cmd/phpup/main.go:53` and `:195`).
+
+`smoke-action` already has `needs: pipeline`, so the artifact is guaranteed to exist by the time `smoke-action` cells start.
+
+### 2.4 No changes elsewhere
+
+- `pipeline` test execution: already self-contained, no change.
+- `publish` job: still gated on `main`. The smoke pass on PRs comes from the PR-local layout; the eventual GHCR push still happens only post-merge.
+- `bundles.lock` semantics: unchanged. PR runs do not commit a lockfile update to the PR head.
+
+## 3. Verification
+
+Per CLAUDE.md "CI failures: reproduce locally first" — every step verifiable on a developer machine before pushing.
+
+### 3.1 Unit-level
+
+- `internal/layoutlockfile`: a new test asserts the function emits a valid v2 lockfile from a synthetic layout containing two annotated manifests. Mirrors the style of existing testsuite tests.
+- `cmd/phpup`: a new test for the `phpup internal lockfile-from-layout` CLI wiring (flag parsing, exit codes for missing flags, integration through to a temp `t.TempDir()` layout).
+- Existing `internal/testsuite` tests: unchanged behavior (the shim must produce identical output to the previous inline path).
+
+### 3.2 Local CI cell
+
+`make ci-cell OS=jammy ARCH=x86_64 PHP=8.5` — the existing local repro covers `pipeline` and the test container's lockfile synthesis (which uses the same logic). After the refactor, this must still pass.
+
+### 3.3 PR CI
+
+The PR validates itself: the `smoke-action` cells exercise the new code path. If the PR's CI shows `smoke-action` green for jammy×amd64 / jammy×arm64 / noble×amd64 / noble×arm64 against PHP 8.4 + `redis, intl`, the fix works end-to-end. (Note: this is the first PR where the new logic actually runs against a redis 6.3.0 in-cell build. It's the only valid integration test.)
+
+### 3.4 Post-merge
+
+On merge to main, the same `smoke-action` cells exercise the new path. `publish` is no longer blocked, so the lockfile auto-commit + GHCR push happen. The redis 6.3.0 bundles land on GHCR; the next time anyone uses `@main`, redis works.
+
+## 4. Risk & rollback
+
+### 4.1 Risks
+
+- **Artifact storage cost.** ~20 layouts × N MB each per PR run, retention 7d. Bounded; existing main-only behavior was already producing one set per main push.
+- **Layout-vs-GHCR digest divergence.** The synthesized lockfile uses local-layout digests, which differ from post-publish GHCR digests because `meta.json` carries a build-time timestamp. The testsuite already handles this — same logic.
+- **download-artifact name mismatch.** Smoke matrix is `(os, arch)` × PHP 8.4; pipeline matrix is `(os, arch, php)`. Smoke's download must match `oci-layout-<os>-<arch>-8.4` exactly. A typo here surfaces as the same "not found in lockfile" error we're trying to fix — visible immediately in PR CI.
+- **smoke-action arch normalization.** Smoke uses `amd64`/`arm64`; pipeline uses `x86_64`/`aarch64`. The artifact name must match what pipeline uploaded, so smoke needs to translate (`amd64` → `x86_64`, `arm64` → `aarch64`) before constructing the artifact name.
+
+### 4.2 Rollback
+
+Revert the PR. Pre-PR behavior restores: PRs upload no artifacts, smoke-action queries GHCR + committed lockfile. The deadlock returns, but no regression beyond pre-PR state.
+
+## 5. Success criteria
+
+- `phpup internal lockfile-from-layout --layout ... --out ...` produces a valid v2 lockfile from an oci-layout populated by `phpup build cell`.
+- `make check` passes; new tests pass.
+- PR CI: `pipeline` 20/20 + `smoke-action` 4/4 green in the same PR run.
+- Post-merge to main: `publish` runs, pushes redis 6.3.0 bundles to GHCR, commits `chore(lock): update bundles.lock from pipeline <id>` back to main.
+- Subsequent bundle-changing PRs (e.g., the eventual igbinary 3.2.17 bump in #43) pass `smoke-action` without manual intervention.

--- a/internal/layoutlockfile/layoutlockfile.go
+++ b/internal/layoutlockfile/layoutlockfile.go
@@ -1,0 +1,108 @@
+// Package layoutlockfile synthesises a phpup lockfile JSON from the annotated
+// manifests in a local OCI image layout. The output is consumed by smoke-test
+// runners that need to resolve bundles against a local layout whose digests
+// differ from the embedded bundles.lock.
+package layoutlockfile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/buildrush/setup-php/internal/registry"
+)
+
+// lister is a sub-interface of registry.Store that exposes ListKeyed.
+// The layout backend implements it; remote backends do not.
+type lister interface {
+	ListKeyed(ctx context.Context) ([]registry.KeyedRef, error)
+}
+
+// WriteSynthesized walks the OCI layout at layoutURI, reads each manifest's
+// io.buildrush.bundle.key annotation, and writes a phpup lockfile JSON to
+// outPath. Parent directories of outPath are created as needed.
+//
+// layoutURI must be in the form accepted by registry.Open, e.g.
+// "oci-layout:/abs/path".  outPath is the full filesystem path of the file to
+// create or overwrite.
+//
+// Output JSON shape:
+//
+//	{
+//	  "schema_version": 2,
+//	  "generated_at":   "<RFC3339 UTC>",
+//	  "bundles": {
+//	    "<key>": {"digest": "sha256:...", "spec_hash": "sha256:..."}
+//	  }
+//	}
+//
+// The spec_hash field is omitted for bundles whose annotation is empty.
+func WriteSynthesized(layoutURI, outPath string) error {
+	store, err := registry.Open(layoutURI)
+	if err != nil {
+		return fmt.Errorf("open layout: %w", err)
+	}
+	ls, ok := store.(lister)
+	if !ok {
+		return errors.New("layout store does not implement ListKeyed")
+	}
+	refs, err := ls.ListKeyed(context.Background())
+	if err != nil {
+		return fmt.Errorf("list keyed refs: %w", err)
+	}
+
+	bundles := make(map[string]map[string]string, len(refs))
+	for _, r := range refs {
+		entry := map[string]string{"digest": r.Digest}
+		if r.SpecHash != "" {
+			entry["spec_hash"] = r.SpecHash
+		}
+		bundles[r.Key] = entry
+	}
+
+	doc := map[string]any{
+		"schema_version": 2,
+		"generated_at":   time.Now().UTC().Format(time.RFC3339),
+		"bundles":        bundles,
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal lockfile: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o750); err != nil {
+		return fmt.Errorf("mkdir parent: %w", err)
+	}
+	if err := os.WriteFile(outPath, data, 0o600); err != nil {
+		return fmt.Errorf("write lockfile: %w", err)
+	}
+	return nil
+}
+
+// MainCLI is a flag.NewFlagSet-based entry point suitable for wiring into a
+// CLI subcommand (e.g. "phpup write-layout-lockfile"). It accepts:
+//
+//	--layout <uri>   OCI layout URI, passed verbatim to registry.Open.
+//	--out    <path>  Output file path.
+//
+// Both flags are required; MainCLI returns an error if either is missing.
+func MainCLI(args []string) error {
+	fs := flag.NewFlagSet("write-layout-lockfile", flag.ContinueOnError)
+	layout := fs.String("layout", "", "OCI layout URI (required)")
+	out := fs.String("out", "", "output lockfile path (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *layout == "" {
+		return errors.New("--layout is required")
+	}
+	if *out == "" {
+		return errors.New("--out is required")
+	}
+	return WriteSynthesized(*layout, *out)
+}

--- a/internal/layoutlockfile/layoutlockfile_test.go
+++ b/internal/layoutlockfile/layoutlockfile_test.go
@@ -1,0 +1,165 @@
+package layoutlockfile_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildrush/setup-php/internal/layoutlockfile"
+	"github.com/buildrush/setup-php/internal/registry"
+)
+
+func TestWriteSynthesized(t *testing.T) {
+	ctx := context.Background()
+	layoutDir := filepath.Join(t.TempDir(), "layout")
+	layoutURI := "oci-layout:" + layoutDir
+
+	// Open a fresh layout store and push two annotated manifests.
+	store, err := registry.Open(layoutURI)
+	if err != nil {
+		t.Fatalf("registry.Open: %v", err)
+	}
+
+	bundles := []registry.Annotations{
+		{
+			BundleKey:  "php:8.4:linux:x86_64:nts",
+			BundleName: "php-core-8.4-nts",
+			SpecHash:   "sha256:aabbccdd",
+		},
+		{
+			BundleKey:  "ext:redis:6.2.0:8.4-nts:linux:x86_64",
+			BundleName: "php-ext-redis",
+			SpecHash:   "",
+		},
+	}
+
+	for i, ann := range bundles {
+		ref := registry.Ref{Name: ann.BundleName}
+		body := bytes.NewReader([]byte{byte(i + 1)})
+		if err := store.Push(ctx, ref, body, nil, ann); err != nil {
+			t.Fatalf("Push[%d]: %v", i, err)
+		}
+	}
+
+	// Obtain expected digests from ListKeyed for later assertion.
+	type lister interface {
+		ListKeyed(ctx context.Context) ([]registry.KeyedRef, error)
+	}
+	ls, ok := store.(lister)
+	if !ok {
+		t.Fatal("store does not implement ListKeyed")
+	}
+	refs, err := ls.ListKeyed(ctx)
+	if err != nil {
+		t.Fatalf("ListKeyed: %v", err)
+	}
+	expectedDigest := make(map[string]string, len(refs))
+	expectedSpecHash := make(map[string]string, len(refs))
+	for _, r := range refs {
+		expectedDigest[r.Key] = r.Digest
+		expectedSpecHash[r.Key] = r.SpecHash
+	}
+
+	// Call WriteSynthesized.
+	outPath := filepath.Join(t.TempDir(), "sub", "bundles-override.lock")
+	if err := layoutlockfile.WriteSynthesized(layoutURI, outPath); err != nil {
+		t.Fatalf("WriteSynthesized: %v", err)
+	}
+
+	// Read and parse the output JSON.
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var doc struct {
+		SchemaVersion int                          `json:"schema_version"`
+		GeneratedAt   string                       `json:"generated_at"`
+		Bundles       map[string]map[string]string `json:"bundles"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// Assert schema_version == 2.
+	if doc.SchemaVersion != 2 {
+		t.Errorf("schema_version = %d; want 2", doc.SchemaVersion)
+	}
+
+	// Assert generated_at is non-empty.
+	if doc.GeneratedAt == "" {
+		t.Error("generated_at is empty")
+	}
+
+	// Assert both bundle keys are present with correct digests.
+	for _, ann := range bundles {
+		key := ann.BundleKey
+		entry, ok := doc.Bundles[key]
+		if !ok {
+			t.Errorf("bundles[%q] missing", key)
+			continue
+		}
+		if got, want := entry["digest"], expectedDigest[key]; got != want {
+			t.Errorf("bundles[%q].digest = %q; want %q", key, got, want)
+		}
+		if ann.SpecHash != "" {
+			if got, want := entry["spec_hash"], expectedSpecHash[key]; got != want {
+				t.Errorf("bundles[%q].spec_hash = %q; want %q", key, got, want)
+			}
+		} else {
+			// spec_hash must be absent when empty.
+			if _, present := entry["spec_hash"]; present {
+				t.Errorf("bundles[%q].spec_hash present but should be omitted", key)
+			}
+		}
+	}
+}
+
+func TestMainCLI_MissingFlags(t *testing.T) {
+	// Both --layout and --out are required; missing either should return an error.
+	if err := layoutlockfile.MainCLI([]string{}); err == nil {
+		t.Error("expected error for missing flags, got nil")
+	}
+}
+
+func TestMainCLI_OK(t *testing.T) {
+	ctx := context.Background()
+	layoutDir := filepath.Join(t.TempDir(), "layout")
+	layoutURI := "oci-layout:" + layoutDir
+
+	store, err := registry.Open(layoutURI)
+	if err != nil {
+		t.Fatalf("registry.Open: %v", err)
+	}
+	ann := registry.Annotations{
+		BundleKey:  "php:8.3:linux:aarch64:nts",
+		BundleName: "php-core-8.3-nts",
+	}
+	if err := store.Push(ctx, registry.Ref{Name: ann.BundleName},
+		bytes.NewReader([]byte("y")), nil, ann); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "out.lock")
+	if err := layoutlockfile.MainCLI([]string{
+		"--layout", layoutURI,
+		"--out", outPath,
+	}); err != nil {
+		t.Fatalf("MainCLI: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if sv, _ := doc["schema_version"].(float64); int(sv) != 2 {
+		t.Errorf("schema_version = %v; want 2", doc["schema_version"])
+	}
+}

--- a/internal/testsuite/internalmain.go
+++ b/internal/testsuite/internalmain.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/buildrush/setup-php/internal/layoutlockfile"
 )
 
 // InternalMain is the entry point for `phpup internal …` maintainer-only
 // subcommands. These are sibling commands to `phpup build` and `phpup test`
 // but are separated under the `internal` umbrella because they're meant to
 // be invoked by the outer tooling (e.g. `phpup test` re-enters via
-// `phpup internal test-cell` inside the per-cell container), not driven
+// `phpup internal test-cell` inside the per-cell container, and `smoke-action`
+// in CI invokes `phpup internal lockfile-from-layout` to synthesize a
+// PR-local lockfile from a downloaded oci-layout artifact), not driven
 // directly by users.
 func InternalMain(args []string) error {
 	if len(args) == 0 {
@@ -19,6 +23,8 @@ func InternalMain(args []string) error {
 	switch args[0] {
 	case "test-cell":
 		return RunTestCell(context.Background(), args[1:])
+	case "lockfile-from-layout":
+		return layoutlockfile.MainCLI(args[1:])
 	default:
 		return fmt.Errorf("phpup internal: unknown subcommand %q", args[0])
 	}

--- a/internal/testsuite/runner.go
+++ b/internal/testsuite/runner.go
@@ -2,7 +2,6 @@ package testsuite
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,10 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/buildrush/setup-php/internal/build"
-	"github.com/buildrush/setup-php/internal/registry"
+	"github.com/buildrush/setup-php/internal/layoutlockfile"
 )
 
 // Main is the entry point for `phpup test …`. Parses flags, expands the
@@ -363,50 +361,15 @@ func buildCellMounts(opts *testOpts, _, _, _ string) ([]build.Mount, map[string]
 	return mounts, env, nil
 }
 
-// writeLayoutLockfileOverride walks the oci-layout's annotated manifests and
-// emits a lockfile JSON file mapping each manifest's io.buildrush.bundle.key
-// annotation to its actual digest. Written under <absRepo>/.cache/phpup-test/
-// so it's inside the gitignored cache tree; returns the absolute path for
-// mounting into the test container.
+// writeLayoutLockfileOverride synthesizes a lockfile from the per-cell oci-layout
+// and writes it under <absRepo>/.cache/phpup-test/. Returns the absolute path so
+// callers can mount it into the test container. Wraps internal/layoutlockfile;
+// the cache-path policy is testsuite-specific so it stays here.
 func writeLayoutLockfileOverride(absLayout, absRepo string) (string, error) {
-	store, err := registry.Open("oci-layout:" + absLayout)
-	if err != nil {
-		return "", fmt.Errorf("open layout: %w", err)
-	}
-	type lister interface {
-		ListKeyed(ctx context.Context) ([]registry.KeyedRef, error)
-	}
-	listerStore, ok := store.(lister)
-	if !ok {
-		return "", fmt.Errorf("layout store does not implement ListKeyed")
-	}
-	refs, err := listerStore.ListKeyed(context.Background())
-	if err != nil {
-		return "", fmt.Errorf("list keyed refs: %w", err)
-	}
-	bundles := make(map[string]map[string]string, len(refs))
-	for _, r := range refs {
-		bundles[r.Key] = map[string]string{"digest": r.Digest}
-		if r.SpecHash != "" {
-			bundles[r.Key]["spec_hash"] = r.SpecHash
-		}
-	}
-	doc := map[string]any{
-		"schema_version": 2,
-		"generated_at":   time.Now().UTC().Format(time.RFC3339),
-		"bundles":        bundles,
-	}
-	data, err := json.MarshalIndent(doc, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal lockfile: %w", err)
-	}
 	outDir := filepath.Join(absRepo, ".cache", "phpup-test")
-	if err := os.MkdirAll(outDir, 0o750); err != nil {
-		return "", fmt.Errorf("mkdir cache: %w", err)
-	}
 	outPath := filepath.Join(outDir, "bundles-override.lock")
-	if err := os.WriteFile(outPath, data, 0o644); err != nil { //nolint:gosec // non-sensitive override file; mounted read-only into ephemeral test container.
-		return "", fmt.Errorf("write lockfile: %w", err)
+	if err := layoutlockfile.WriteSynthesized("oci-layout:"+absLayout, outPath); err != nil {
+		return "", err
 	}
 	return outPath, nil
 }


### PR DESCRIPTION
## Summary

- Drops the \`if: github.ref == 'refs/heads/main'\` gate on \`pipeline.Upload oci-layout artifact\` so PRs upload per-cell layouts (retention 7d).
- Adds \`phpup internal lockfile-from-layout --layout oci-layout:<path> --out <file>\` subcommand, factored out of \`internal/testsuite/runner.go:writeLayoutLockfileOverride\` into a shared \`internal/layoutlockfile\` package.
- \`smoke-action\` downloads the matching pipeline cell's oci-layout, synthesizes a lockfile override, and sets \`PHPUP_REGISTRY=oci-layout:<path>\` + \`PHPUP_LOCKFILE=<override>\` for the \`uses: ./\` action invocation. Translates \`amd64\`/\`arm64\` matrix labels to pipeline's \`x86_64\`/\`aarch64\` for the artifact name.

Closes #83.

## Why

The unified \`ci.yml\` (PR #59 / #60) introduced a deadlock: \`smoke-action\` resolved bundles through the committed \`bundles.lock\` + GHCR, but \`publish\` (which writes the lockfile and pushes to GHCR) is \`needs: [pipeline, smoke-action]\` — so any PR that bumped a bundle version failed \`smoke-action\`, blocked \`publish\`, and stalled the lockfile-update flow. PR #76 (redis 6.3.0) is the first PR to surface this; main has been in a regressed state since that merge (catalog says 6.3.0, but \`bundles.lock\` + GHCR still on 6.2.0).

After this change, \`smoke-action\` validates against the PR's own pipeline-built bundles end-to-end with no GHCR roundtrip — matching the design in \`docs/superpowers/specs/2026-04-23-local-ci-unification-design.md\` and \`2026-04-20-bundle-schema-and-rollout-design.md\`. Once this lands on main, \`publish\` runs cleanly, the redis 6.3.0 bundles get pushed to GHCR, and \`bundles.lock\` auto-updates to include \`ext:redis:6.3.0:*\` entries.

## Test plan

- [ ] CI: \`pipeline\` 20/20 pass.
- [ ] CI: \`smoke-action\` 4/4 pass (jammy/amd64, jammy/arm64, noble/amd64, noble/arm64) using PR-local bundles. **This is the first PR where smoke validates the new code path against a redis 6.3.0 in-cell build — green here means the deadlock is fixed.**
- [ ] CI: \`make check\` passes; new \`internal/layoutlockfile\` tests pass.
- [ ] Post-merge: \`publish\` runs on main, pushes redis 6.3.0 bundles to GHCR, commits \`chore(lock): update bundles.lock from pipeline <id>\`.

Spec: \`docs/superpowers/specs/2026-04-27-smoke-action-pr-self-containment-design.md\`