### PR TITLE
ci: grant publish job contents:write for lockfile auto-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,13 @@ jobs:
     needs: [pipeline, smoke-action]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
+    permissions:
+      # Override the workflow-level contents:read so this job can push
+      # the bundles.lock auto-update commit back to main. Other jobs keep
+      # the read-only default — only publish needs write access.
+      contents: write
+      packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Adds a job-level \`permissions:\` block to \`publish\` granting \`contents: write\`, while leaving the workflow-level \`contents: read\` default for every other job. Minimum-privilege: only the \`publish\` job needs write access (to push the \`bundles.lock\` auto-update commit back to main).

## Why

Post-merge run for #85 (\`24988341535\`) revealed:

| step | result |
|---|---|
| Promote to GHCR | ✅ pass — redis 6.3.0 bundles pushed |
| Update lockfile | ✅ pass — local \`bundles.lock\` updated |
| **Commit lockfile (if changed)** | ❌ **fail** — \`git push\` rejected with HTTP 403 |

\`\`\`
fatal: unable to access 'https://github.com/buildrush/setup-php/': The requested URL returned error: 403
\`\`\`

Root cause: the workflow-level \`permissions:\` block (lines 14–17) grants only \`contents: read\`. The \`publish\` job inherits that and the \`GITHUB_TOKEN\` it uses for the \`actions/checkout\` (\`token: \${{ secrets.GITHUB_TOKEN }}\`) cannot push.

After this change, \`publish\` runs end-to-end on the next push to main, the \`chore(lock): update bundles.lock from pipeline <id>\` commit lands, and the in-tree lockfile rejoins the GHCR registry state.

## State of main right now

- \`bundles.lock\` (in-tree): \`ext:redis:6.2.0:{8.1..8.4}:*\` — pre-#76.
- GHCR: redis 6.3.0 bundles already promoted (the post-merge publish for #85 succeeded at the GHCR step).
- Catalog: redis 6.3.0 — \`phpup install\` against main's HEAD currently fails for redis lookups because the lockfile is out of sync with the catalog and registry.

Once this PR merges and the next \`publish\` job runs on main, the lockfile catches up and the regression resolves.

## Test plan

- [ ] CI on this PR: lint + unit + 20 pipeline + 4 smoke all green (no functional change).
- [ ] Post-merge on main: \`publish\` step \`Commit lockfile (if changed)\` succeeds.
- [ ] Post-publish: \`gh api 'repos/buildrush/setup-php/contents/bundles.lock?ref=main' --jq .content | base64 -d | grep -c '"ext:redis:6.3.0:'\` returns 10.

Related: #38 (redis bump, PR #76), #83 (smoke-action self-containment, PR #85).