### PR TITLE
ci(publish): walk per-cell layouts instead of merging into one dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,18 +247,36 @@ jobs:
       - name: Build phpup
         run: make bin/phpup
       - name: Download all oci-layout artifacts
+        # Each cell's artifact lands in its own subdirectory:
+        #   out/oci-layout-<os>-<arch>-<php>/<oci-layout files>
+        # We deliberately do NOT use merge-multiple here — that flag
+        # overwrites colliding files (every cell's oci-layout/index.json
+        # lives at the same relative path), losing 19 cells' worth of
+        # manifest entries even though the blob bytes survive in
+        # blobs/sha256/. Promote walks each layout separately instead.
         uses: actions/download-artifact@v8
         with:
           pattern: oci-layout-*
-          path: out/merged-layout
-          merge-multiple: true
+          path: out
       - name: Promote to GHCR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          bin/phpup push \
-            --from "oci-layout:$(pwd)/out/merged-layout" \
-            --to "ghcr.io/${{ github.repository_owner }}"
+          set -euo pipefail
+          shopt -s nullglob
+          layouts=(out/oci-layout-*/)
+          if [ "${#layouts[@]}" -eq 0 ]; then
+            echo "::error::no oci-layout-* artifacts found under out/"
+            exit 1
+          fi
+          for layoutdir in "${layouts[@]}"; do
+            echo "::group::Promote $layoutdir"
+            bin/phpup push \
+              --from "oci-layout:$(pwd)/${layoutdir%/}" \
+              --to "ghcr.io/$OWNER"
+            echo "::endgroup::"
+          done
       - name: Update lockfile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

\`actions/download-artifact@v8\` with \`merge-multiple: true\` was overwriting each cell's \`oci-layout/index.json\` during the merge — every artifact's index lives at the same relative path, so the merge kept only the last cell's index entries. Cell blob bytes survived in \`blobs/sha256/\` but were unreferenced; \`phpup push\` only saw a fraction of the manifests it should have promoted.

This PR drops \`merge-multiple\`, lets each artifact land in its own subdirectory (\`out/oci-layout-<os>-<arch>-<php>/\`), and loops over them in the Promote step so each \`phpup push\` invocation sees a complete per-cell index. Net work is identical — each manifest is still pushed exactly once.

## How this surfaced

Post-merge of #87 (the canonical-tag fix), \`Promote to GHCR\` correctly used canonical tags. But only **1 of 10** redis 6.3.0 canonical tags landed on GHCR (\`6.3.0-8.4-nts-linux-x86_64\` only). The \`Update lockfile\` step then 404'd on the other 9 cells. Confirmed root cause by inspection: \`merge-multiple: true\` overwrites colliding paths in the destination dir.

## Test plan

- [ ] CI on this PR: lint + unit + 20 pipeline + 4 smoke pass (no functional change for these jobs).
- [ ] Post-merge on main: the Promote step pushes 39 manifests across all 20 layouts. GHCR ends up with all 10 redis 6.3.0 canonical tags (\`6.3.0-{8.1..8.5}-nts-linux-{x86_64,aarch64}\`).
- [ ] Post-merge on main: \`Update lockfile\` step succeeds with no \"skip … 404\" warnings for redis 6.3.0; the regenerated bundles.lock contains all 10 \`ext:redis:6.3.0:*\` entries.

(The \`Commit lockfile (if changed)\` step still hits the repository ruleset and will fail. That's a separate concern — once GHCR has all 10 redis 6.3.0 tags, a maintainer can run \`phpup lockfile-update\` locally and open a one-line bundles.lock PR; or a follow-up workflow change can switch the auto-commit to a bot-PR flow.)

## Related

- #38 — redis 6.3.0 bump (PR #76, merged).
- #83 — smoke-action self-containment (PR #85, merged).
- PR #86 — granted publish job \`contents:write\`.
- PR #87 — fix \`phpup push\` to use canonical tags + propagate annotations.